### PR TITLE
상세페이지에서 리뷰, 별점 저장 및 수정 가능

### DIFF
--- a/src/app/api/review/memo/route.ts
+++ b/src/app/api/review/memo/route.ts
@@ -53,17 +53,27 @@ export async function POST(request: Request) {
         }
       );
     }    
-    return Response.json({ message: "성공적으로 리뷰가 업데이트 되었습니다" });
-  } catch (error) {
-    console.error("❌POST요청 처리 중 에러 발생:", error);
-    return Response.json({ error: "Internal Server Error" }, { status: 500 });
+
+    const latestReview = await MemberStore.findOne(
+      { userId },
+        {
+          memo: { $elemMatch: { cocktail_id: cocktailId } },
+        }
+    );
+    
+      return NextResponse.json({
+          message: "성공적으로 리뷰가 업데이트 되었습니다.",
+          memo: latestReview?.memo?.[0] || null, 
+        });
+      } catch (error) {
+        console.error("❌POST요청 처리 중 에러 발생:", error);
+        return Response.json({ error: "Internal Server Error" }, { status: 500 });
+      }
   }
-}
 
 export async function GET(request: Request) {
   try {
     connectDB();
-    // 쿼리에서 cocktailId 추출
     const { searchParams } = new URL(request.url);
     const cocktailId = searchParams.get("cocktailId");
     console.log("✅ 쿼리로 받은 cocktailId:", cocktailId);

--- a/src/app/api/review/memo/route.ts
+++ b/src/app/api/review/memo/route.ts
@@ -71,6 +71,45 @@ export async function POST(request: Request) {
       }
   }
 
+export async function DELETE(request: Request) {
+  try {
+    connectDB();
+    const { searchParams } = new URL(request.url);
+    const cocktailId = searchParams.get("cocktailId");
+
+    // getToken 사전준비 header에서 cookie 가져오기
+    const reqHeaders = headers();
+    const cookie = reqHeaders.get("cookie") || "";
+
+    // NextRequest 객체 생성
+    const req = new NextRequest("http://localhost", { headers: { cookie } });
+
+    // `getToken()`을 사용하여 JWT 토큰 데이터 가져오기
+    const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET! });
+
+    if (!token) {
+      return NextResponse.json({ error: "유저 정보를 찾을 수 없습니다." }, { status: 404 });
+    }
+    const userId = token.id;
+    await MemberStore.updateOne(
+        { userId },
+          {
+            $unset: {
+              "memo.$[elem].memo_txt": "", 
+            },
+          },
+        {
+          arrayFilters: [{ "elem.cocktail_id": cocktailId }],
+        }
+    );
+    return NextResponse.json({message: "성공적으로 리뷰가 삭제 되었습니다.",});
+
+    }catch (error) {
+      console.error("❌ DELETE요청 처리 중 에러 발생:", error);
+      return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+}
+
 export async function GET(request: Request) {
   try {
     connectDB();

--- a/src/app/api/review/memo/route.ts
+++ b/src/app/api/review/memo/route.ts
@@ -95,7 +95,7 @@ export async function DELETE(request: Request) {
         { userId },
           {
             $unset: {
-              "memo.$[elem].memo_txt": "", 
+              "memo.$[elem].memo_txt": 1, // 리뷰 삭제 - 값에다 1을 넣어주면 삭제됨 
             },
           },
         {

--- a/src/app/api/review/rating/route.ts
+++ b/src/app/api/review/rating/route.ts
@@ -10,7 +10,7 @@ export async function POST(request: Request) {
   try {
     connectDB();
     const body = await request.json();
-    const { reviewText, cocktailId } = body;
+    const { rating, cocktailId } = body;
     console.log("request 값입니다.",body);
 
     // getToken 사전준비 header에서 cookie 가져오기
@@ -35,27 +35,14 @@ export async function POST(request: Request) {
       { userId, "memo.cocktail_id": cocktailId },
       {
         $set: {
-          ...(reviewText && { "memo.$.memo_txt": reviewText }),
-        }, 
+          "memo.$.rating": rating, // 항상 업데이트
+        },
       }
-    );
-    // 칵테일 리뷰가 없으면 새로 추가
-    if (updatedUserStore.modifiedCount === 0) {
-      await MemberStore.updateOne(
-        { userId }, // userId가 일치하는 문서를 찾음
-        {
-          $push: {
-            memo: {
-              cocktail_id: cocktailId,
-              memo_txt: reviewText,
-            },
-          },
-        }
-      );
-    }    
-    return Response.json({ message: "성공적으로 리뷰가 업데이트 되었습니다" });
+    );   
+ 
+    return Response.json({ message: "성공적으로 별점이 업데이트 되었습니다" });
   } catch (error) {
-    console.error("❌POST요청 처리 중 에러 발생:", error);
+    console.error("❌rating POST요청 처리 중 에러 발생:", error);
     return Response.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }
@@ -94,7 +81,7 @@ export async function GET(request: Request) {
     );
     return Response.json(getUserReview);
   } catch (error) {
-    console.error("❌ GET요청 처리 중 에러 발생:", error);
+    console.error("❌rating GET요청 처리 중 에러 발생:", error);
     return Response.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }

--- a/src/app/desc/[id]/desc.module.scss
+++ b/src/app/desc/[id]/desc.module.scss
@@ -260,7 +260,9 @@
   background-color:$gray-100; // 구분선 색상
   margin: 1rem 0;
 }
-
+.reviewText {
+  text-align: center;
+}
 .reviewText textarea  {
   width: 100%;
   padding: 3rem;

--- a/src/app/desc/[id]/desc.module.scss
+++ b/src/app/desc/[id]/desc.module.scss
@@ -282,6 +282,8 @@
   font-style: $light;
   text-align: center;
 }
+
+// 수정 & 삭제 버튼 같이 들어갈 div 스타일
 .buttonBox {
   display: flex;
   flex-direction: row;
@@ -291,28 +293,16 @@
   gap: 2rem;
   margin-top: 3rem;
 }
-// 공통 버튼 스타일
-.buttonBase {
-  color: #ffffff;
-  border: none;
-  border-radius: 2rem;
-  padding: 1rem 5rem;
-  font-size: 2rem;
-  font-weight: $bold;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-}
+// 버튼 스타일
 .saveButton {
-  @extend .buttonBase;
-  background-color: $main-color;
-
+  cursor: pointer;
+  
   &:hover {
     background-color: #ffc293;
   }
 }
 .deleteButton {
-  @extend .buttonBase;
-  background-color: #f33939;
+  cursor: pointer;
 
   &:hover {
     background-color: #ff888a;
@@ -336,4 +326,23 @@
   height: 3rem;
   width: 3rem;
   background-position: center;
+}
+.loginModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5); // 어두운 배경
+  box-shadow: $shadow;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000; // 다른 요소보다 위에
+
+  // .close {
+  //   position: absolute;
+  //   top: 2rem;
+  //   right: 2rem;
+  // }
 }

--- a/src/app/desc/[id]/desc.module.scss
+++ b/src/app/desc/[id]/desc.module.scss
@@ -282,8 +282,17 @@
   font-style: $light;
   text-align: center;
 }
-.saveButton {
-  background-color: $main-color;
+.buttonBox {
+  display: flex;
+  flex-direction: row;
+  gap: 2rem;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+  margin-top: 3rem;
+}
+// 공통 버튼 스타일
+.buttonBase {
   color: #ffffff;
   border: none;
   border-radius: 2rem;
@@ -292,9 +301,21 @@
   font-weight: $bold;
   cursor: pointer;
   transition: background-color 0.3s ease;
+}
+.saveButton {
+  @extend .buttonBase;
+  background-color: $main-color;
 
   &:hover {
     background-color: #ffc293;
+  }
+}
+.deleteButton {
+  @extend .buttonBase;
+  background-color: #f33939;
+
+  &:hover {
+    background-color: #ff888a;
   }
 }
 

--- a/src/app/desc/[id]/desc.module.scss
+++ b/src/app/desc/[id]/desc.module.scss
@@ -113,10 +113,9 @@
 }
 
 .baseImg, .flavorImg {
-  width: 2rem;
-  height: 2rem;
-  margin: 5rem;
-  padding : 3r
+  width: 5rem;
+  height: 5rem;
+  margin: 4rem;
 }
 
 .slider {

--- a/src/app/desc/[id]/page.tsx
+++ b/src/app/desc/[id]/page.tsx
@@ -5,12 +5,14 @@ import { useMemberStore } from "@/lib/store/memberStore";
 import { useRef, useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 
-import { postReview, getReviews } from "@/lib/fetchs/fetchReview";
+import { postReview, getReview } from "@/lib/fetchs/fetchReview";
+import { postRating, getRating } from "@/lib/fetchs/fetchRating";
 import Navigation from "@/components/common/navigation/Navigation";
 import style from "./Desc.module.scss";
 import StarRating from "@public/StarRating.svg";
 
 export default function Desc({}) {
+  console.log("🔁 Desc 컴포넌트 렌더링됨");
   const { id } = useParams();
   const { cocktailList } = useCocktailStore();
   const { memo, setMemo } = useMemberStore();
@@ -18,40 +20,52 @@ export default function Desc({}) {
   const [hover, setHover] = useState(0);
   const reviewRef = useRef<HTMLTextAreaElement>(null);
   const { data: session } = useSession();
+  const [isEditing, setIsEditing] = useState(false);
+  const matchedMemo = Array.isArray(memo)
+    ? memo.find((item: any) => item && item.cocktail_id === id)
+    : null;
 
   useEffect(() => {
-    console.log("세션 정보", session);
-  }, [session]);
+    if (matchedMemo?.rating) {
+      setRating(matchedMemo.rating);
+    }
+  }, [matchedMemo]);
 
-  const handleRating = (index: number) => {
-    setRating(rating === index + 1 ? 0 : index + 1);
+  const handleRating = async (index: number) => {
+    if (!session) {
+      alert("로그인이 필요합니다.");
+      return;
+    }
+    const newRating = rating === index + 1 ? 0 : index + 1;
+    setRating(newRating);
+    try {
+      const res = await postRating(id, newRating);
+      const { memo } = await res;
+      alert("🌟별점이 저장되었습니다🌟");
+
+      setMemo((prev) => {
+        const safePrev = Array.isArray(prev) ? prev : [];
+        return [...safePrev.filter((m) => m && m.cocktail_id !== id), memo];
+      });
+      const current = useMemberStore.getState().memo;
+      console.log("⭐️ 최신 별점:", current);
+    } catch (error) {
+      console.error("⭐️ 별점 저장 실패:", error);
+    }
   };
-
-  {
-    /*
+  /*
     이 부분은 API로 리뷰 저장하는 부분입니다.
     리뷰 저장을 위해서는 로그인이 필요합니다.
     로그인이 안되어있을 경우, alert 로 로그인 필요 메시지가 뜹니다. 
-    리뷰를 입력하지 않았을 경우, alert 로 리뷰를 입력해주세요 메시지가 뜹니다.
+    리뷰 값이 없고 저장 버튼을 누를 경우, alert 로 리뷰를 입력해주세요 메시지가 뜹니다.
     리뷰가 성공적으로 저장되었을 경우, alert 로 리뷰가 저장되었습니다 메시지가 뜹니다.
     리뷰가 저장되면서 동시에 db 에 업데이트가 됩니다. 
-    db 업데이트는 다음과 같이 이루어집니다.
-    1. 해당 유저의 MemberStore 문서를 찾습니다.
-    2. 해당 유저의 MemberStore 문서에 해당 칵테일의 리뷰가 있는지 확인합니다.
-    3. 해당 유저의 MemberStore 문서에 해당 칵테일의 리뷰가 있으면 업데이트를 합니다.
-    4. 해당 유저의 MemberStore 문서에 해당 칵테일의 리뷰가 없으면 새로운 리뷰를 추가합니다.
-    그와 동시에 zustand의 memberStore 에도 업데이트가 됩니다. -- 추후 구현예정입니다.
+    기존 리뷰가 있을 경우, "저장" 버튼 대신 "수정" 버튼이 뜹니다.
     memberStore 에도 역시 db에 저장된 형식과 같은 형식의 데이터가 저장됩니다.
+    memberStore 값은 useLayout.tsx 에서 페이지 처음 로딩될때 업데이트 됩니다.
   */
-  }
-
   const handleSaveReview = async () => {
     const reviewText = reviewRef.current?.value;
-    const newReview = {
-      cocktail_id: id,
-      memo_txt: reviewText,
-    };
-    console.log("리뷰 저장", newReview);
     if (!reviewText) {
       alert("리뷰를 입력해주세요!");
       return;
@@ -61,18 +75,42 @@ export default function Desc({}) {
       return;
     }
     try {
-      postReview(id, reviewText);
-      setMemo({ ...memo, newReview });
+      const res = await postReview(id, reviewText);
+      const { memo } = await res;
+
+      setMemo((prev) => {
+        const safePrev = Array.isArray(prev) ? prev : [];
+        return [...safePrev.filter((m) => m && m.cocktail_id !== id), memo];
+      });
+      setIsEditing(false); // 다시 읽기 모드로 전환
+
       alert("리뷰가 저장되었습니다.");
     } catch (error) {
       console.error("리뷰 저장 실패:", error);
     }
   };
+  /* 
+    이 부분은 API로 리뷰 삭제하는 부분입니다.
+    리뷰 삭제를 위해서는 로그인이 필요합니다.
+    아직 진행중..
+ */
+  // const handleDeleteReview = async () => {
+  //   if (!session) {
+  //     alert("로그인이 필요합니다.");
+  //     return;
+  //   }
+  //   const confirmDelete = confirm("정말 리뷰를 삭제하시겠어요?");
+  //   if (!confirmDelete) return;
+  //   try {
+  //     const res = await fetch(`/api/review/memo?cocktailId=${id}`, {
+  //       method: "DELETE",
+  //     });
+
+  //     if (!res.ok) throw new Error("리뷰 삭제 실패");
 
   const cocktail = cocktailList.find((cocktail) => cocktail._id === id);
-
   // 데이터가 없는 경우 처리
-  if (!cocktailList) {
+  if (!cocktail) {
     return <div>칵테일 정보를 찾을 수 없습니다.</div>;
   }
 
@@ -127,6 +165,7 @@ export default function Desc({}) {
           <div className={style.slider}>
             <span>SWEET</span>
             <input
+              readOnly
               className={`${style.input}`}
               type="range"
               min="1"
@@ -136,6 +175,7 @@ export default function Desc({}) {
             <span>DRY</span>
             <span>GENTLE</span>
             <input
+              readOnly
               className={`${style.input}`}
               type="range"
               min="1"
@@ -184,29 +224,62 @@ export default function Desc({}) {
         <div className={`${style.reviewBox}`}>
           <div className={`${style.stars}`}>
             {[...Array(5)].map((_, index) => (
-              <StarRating
-                key={index}
-                className={`${style.star} ${
-                  index < rating ? style.filled : ""
-                } ${index < hover ? style.hovered : ""}`}
-                onClick={() => handleRating(index)}
-                onMouseEnter={() => setHover(index + 1)}
-                onMouseLeave={() => setHover(0)}
-              />
-            ))}
+              <div
+                key={`star-wrapper-${index}`}
+                onClick={() => {
+                  handleRating(index);
+                }}
+              >
+                <StarRating
+                  key={{ index }}
+                  className={`${style.star} ${
+                    index < rating ? style.filled : ""
+                  } ${index < hover ? style.hovered : ""}`}
+                  onMouseEnter={() => setHover(index + 1)}
+                  onMouseLeave={() => setHover(0)}
+                />
+              </div>
+            ))}{" "}
           </div>
           <div className={`${style.divider}`} />
           <div className={`${style.reviewText}`}>
-            <textarea
-              // value={memo. ? memo : ""}
-              ref={reviewRef}
-              placeholder="칵테일 맛이 어땠나요? 리뷰를 남겨보세요."
-            />
+            <div className={style.reviewText}>
+              {matchedMemo && !isEditing ? (
+                <div>{matchedMemo.memo_txt}</div>
+              ) : (
+                <textarea
+                  ref={reviewRef}
+                  defaultValue={matchedMemo?.memo_txt || ""}
+                  placeholder="칵테일 맛이 어땠나요? 리뷰를 남겨보세요."
+                />
+              )}
+            </div>{" "}
           </div>
         </div>
-        <button className={style.saveButton} onClick={handleSaveReview}>
-          저장
-        </button>
+        {matchedMemo ? (
+          isEditing ? (
+            <>
+              <button className={style.saveButton} onClick={handleSaveReview}>
+                저장
+              </button>
+              <button className={style.deleteButton}>삭제</button>
+            </>
+          ) : (
+            <>
+              <button
+                className={style.saveButton}
+                onClick={() => setIsEditing(true)}
+              >
+                수정
+              </button>
+              <button className={style.deleteButton}>삭제</button>
+            </>
+          )
+        ) : (
+          <button className={style.saveButton} onClick={handleSaveReview}>
+            저장
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/app/desc/[id]/page.tsx
+++ b/src/app/desc/[id]/page.tsx
@@ -2,6 +2,7 @@
 import { useParams } from "next/navigation";
 import { useCocktailStore } from "@/lib/store/cocktailStore";
 import { useMemberStore } from "@/lib/store/memberStore";
+import { useEmojiStore } from "@/lib/store/emojiStore";
 import { useRef, useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 
@@ -18,6 +19,7 @@ export default function Desc({}) {
   const { id } = useParams();
   const { cocktailList } = useCocktailStore();
   const { memo, setMemo } = useMemberStore();
+  const { emojiList, fetchEmoji } = useEmojiStore();
   const [rating, setRating] = useState(0);
   const [hover, setHover] = useState(0);
   const reviewRef = useRef<HTMLTextAreaElement>(null);
@@ -33,6 +35,10 @@ export default function Desc({}) {
       setRating(matchedMemo.rating);
     }
   }, [matchedMemo]);
+
+  useEffect(() => {
+    fetchEmoji();
+  }, []);
 
   const handleRating = async (index: number) => {
     if (!session) {
@@ -122,7 +128,18 @@ export default function Desc({}) {
       console.error("리뷰 삭제 실패:", error);
     }
   };
+  // 수많은 칵테일 중 id에 해당하는 칵테일을 찾기
   const cocktail = cocktailList.find((cocktail) => cocktail._id === id);
+  // 해당 칵테일의 데이터와 이모지를 매칭하기
+  const cocktailBase = emojiList.find((emoji) =>
+    emoji.value.includes(cocktail?.base)
+  );
+  const cocktailFlavor = emojiList.find((emoji) =>
+    emoji.value.includes(cocktail?.flavor)
+  );
+  console.log("🍹 cocktailFlavor", cocktailFlavor);
+  console.log("🍹 baseAndTastingnote", cocktailBase);
+  console.log("🍹 cocktail", cocktail);
   // 데이터가 없는 경우 처리
   if (!cocktail) {
     return <div>칵테일 정보를 찾을 수 없습니다.</div>;
@@ -159,19 +176,23 @@ export default function Desc({}) {
               <span>베이스</span>
               <img
                 className={style.baseImg}
-                src="맞는 이미지 넣기"
+                src={cocktailBase?.url || emojiList[1].url}
                 alt="Base Image"
               />
-              <div className={style.baseName}>{cocktail?.base}</div>
+              <div className={style.baseName}>
+                {cocktail?.base || "준비 중"}
+              </div>
             </div>
             <div className={style.flavor}>
               <span>테이스팅 노트</span>
               <img
                 className={style.flavorImg}
-                src="맞는 이미지 넣기"
+                src={cocktailFlavor?.url || emojiList[1].url}
                 alt="Flavor Image"
               />
-              <div className={style.flavorName}>{cocktail?.flavor}</div>
+              <div className={style.flavorName}>
+                {cocktail?.flavor || "준비 중"}
+              </div>
             </div>
           </div>
 

--- a/src/app/desc/[id]/page.tsx
+++ b/src/app/desc/[id]/page.tsx
@@ -7,7 +7,9 @@ import { useSession } from "next-auth/react";
 
 import { postReview, getReview, deleteReview } from "@/lib/fetchs/fetchReview";
 import { postRating, getRating } from "@/lib/fetchs/fetchRating";
+import LoginModal from "@/components/common/modal/LoginModal";
 import Navigation from "@/components/common/navigation/Navigation";
+import Button from "@/components/common/button/Button";
 import style from "./Desc.module.scss";
 import StarRating from "@public/StarRating.svg";
 
@@ -21,6 +23,7 @@ export default function Desc({}) {
   const reviewRef = useRef<HTMLTextAreaElement>(null);
   const { data: session } = useSession();
   const [isEditing, setIsEditing] = useState(false);
+  const [isLoginOpen, setIsLoginOpen] = useState(false);
   const matchedMemo = Array.isArray(memo)
     ? memo.find((item: any) => item && item.cocktail_id === id)
     : null;
@@ -33,7 +36,7 @@ export default function Desc({}) {
 
   const handleRating = async (index: number) => {
     if (!session) {
-      alert("로그인이 필요합니다.");
+      setIsLoginOpen(true);
       return;
     }
     const newRating = rating === index + 1 ? 0 : index + 1;
@@ -67,11 +70,11 @@ export default function Desc({}) {
   const handleSaveReview = async () => {
     const reviewText = reviewRef.current?.value;
     if (!reviewText) {
-      alert("리뷰를 입력해주세요!");
+      alert("리뷰를 입력해주세요.");
       return;
     }
     if (!session) {
-      alert("로그인이 필요합니다.");
+      setIsLoginOpen(true);
       return;
     }
     try {
@@ -96,7 +99,7 @@ export default function Desc({}) {
  */
   const handleDeleteReview = async () => {
     if (!session) {
-      alert("로그인이 필요합니다.");
+      setIsLoginOpen(true);
       return;
     }
     const confirmDelete = confirm("정말 리뷰를 삭제하시겠어요?");
@@ -269,33 +272,39 @@ export default function Desc({}) {
         </div>
         {matchedMemo?.memo_txt ? (
           isEditing ? (
-            <>
-              <button className={style.saveButton} onClick={handleSaveReview}>
-                저장
-              </button>
-            </>
+            <Button
+              text="저장"
+              color="orange"
+              className={`${style.saveButton}`}
+              onClick={handleSaveReview}
+            />
           ) : (
             <div className={`${style.buttonBox}`}>
-              <button
-                className={style.saveButton}
+              <Button
+                text="수정"
+                color="orange"
+                className={`${style.saveButton}`}
                 onClick={() => setIsEditing(true)}
-              >
-                수정
-              </button>
-              <button
-                className={style.deleteButton}
+              />
+              <Button
+                text="삭제"
+                color="red"
+                className={`${style.deleteButton}`}
                 onClick={handleDeleteReview}
-              >
-                삭제
-              </button>
+              />
             </div>
           )
         ) : (
-          <button className={style.saveButton} onClick={handleSaveReview}>
-            저장
-          </button>
+          <Button
+            text="저장"
+            color="orange"
+            className={`${style.saveButton}`}
+            onClick={handleSaveReview}
+          />
         )}
       </div>
+      {/* 로그인 요청 알림 모달 */}
+      {isLoginOpen && <LoginModal onClose={() => setIsLoginOpen(false)} />}
     </div>
   );
 }

--- a/src/app/desc/[id]/page.tsx
+++ b/src/app/desc/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useMemberStore } from "@/lib/store/memberStore";
 import { useRef, useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 
-import { postReview, getReview } from "@/lib/fetchs/fetchReview";
+import { postReview, getReview, deleteReview } from "@/lib/fetchs/fetchReview";
 import { postRating, getRating } from "@/lib/fetchs/fetchRating";
 import Navigation from "@/components/common/navigation/Navigation";
 import style from "./Desc.module.scss";
@@ -83,7 +83,7 @@ export default function Desc({}) {
         return [...safePrev.filter((m) => m && m.cocktail_id !== id), memo];
       });
       setIsEditing(false); // 다시 읽기 모드로 전환
-
+      console.log("store 최신 리뷰", useMemberStore.getState().memo);
       alert("리뷰가 저장되었습니다.");
     } catch (error) {
       console.error("리뷰 저장 실패:", error);
@@ -94,20 +94,31 @@ export default function Desc({}) {
     리뷰 삭제를 위해서는 로그인이 필요합니다.
     아직 진행중..
  */
-  // const handleDeleteReview = async () => {
-  //   if (!session) {
-  //     alert("로그인이 필요합니다.");
-  //     return;
-  //   }
-  //   const confirmDelete = confirm("정말 리뷰를 삭제하시겠어요?");
-  //   if (!confirmDelete) return;
-  //   try {
-  //     const res = await fetch(`/api/review/memo?cocktailId=${id}`, {
-  //       method: "DELETE",
-  //     });
+  const handleDeleteReview = async () => {
+    if (!session) {
+      alert("로그인이 필요합니다.");
+      return;
+    }
+    const confirmDelete = confirm("정말 리뷰를 삭제하시겠어요?");
+    if (!confirmDelete) return;
+    try {
+      const res = await deleteReview(id);
+      console.log("🔍 삭제 응답 상태 코드:", res.status);
+      if (!res.ok) throw new Error("리뷰 삭제 실패");
+      setMemo((prev) => {
+        const safePrev = Array.isArray(prev) ? prev : [];
+        return safePrev.map((m) =>
+          m && m.cocktail_id === id ? { ...m, memo_txt: undefined } : m
+        );
+      });
+      console.log("store 최신 리뷰", useMemberStore.getState().memo);
 
-  //     if (!res.ok) throw new Error("리뷰 삭제 실패");
-
+      setIsEditing(true);
+      alert("🔥⛄🔥리뷰가 삭제되었습니다.");
+    } catch (error) {
+      console.error("리뷰 삭제 실패:", error);
+    }
+  };
   const cocktail = cocktailList.find((cocktail) => cocktail._id === id);
   // 데이터가 없는 경우 처리
   if (!cocktail) {
@@ -239,7 +250,7 @@ export default function Desc({}) {
                   onMouseLeave={() => setHover(0)}
                 />
               </div>
-            ))}{" "}
+            ))}
           </div>
           <div className={`${style.divider}`} />
           <div className={`${style.reviewText}`}>
@@ -253,7 +264,7 @@ export default function Desc({}) {
                   placeholder="칵테일 맛이 어땠나요? 리뷰를 남겨보세요."
                 />
               )}
-            </div>{" "}
+            </div>
           </div>
         </div>
         {matchedMemo ? (
@@ -262,18 +273,22 @@ export default function Desc({}) {
               <button className={style.saveButton} onClick={handleSaveReview}>
                 저장
               </button>
-              <button className={style.deleteButton}>삭제</button>
             </>
           ) : (
-            <>
+            <div className={`${style.buttonBox}`}>
               <button
                 className={style.saveButton}
                 onClick={() => setIsEditing(true)}
               >
                 수정
               </button>
-              <button className={style.deleteButton}>삭제</button>
-            </>
+              <button
+                className={style.deleteButton}
+                onClick={handleDeleteReview}
+              >
+                삭제
+              </button>
+            </div>
           )
         ) : (
           <button className={style.saveButton} onClick={handleSaveReview}>

--- a/src/app/desc/[id]/page.tsx
+++ b/src/app/desc/[id]/page.tsx
@@ -255,7 +255,7 @@ export default function Desc({}) {
           <div className={`${style.divider}`} />
           <div className={`${style.reviewText}`}>
             <div className={style.reviewText}>
-              {matchedMemo && !isEditing ? (
+              {matchedMemo?.memo_txt && !isEditing ? (
                 <div>{matchedMemo.memo_txt}</div>
               ) : (
                 <textarea
@@ -267,7 +267,7 @@ export default function Desc({}) {
             </div>
           </div>
         </div>
-        {matchedMemo ? (
+        {matchedMemo?.memo_txt ? (
           isEditing ? (
             <>
               <button className={style.saveButton} onClick={handleSaveReview}>

--- a/src/components/common/button/Button.module.scss
+++ b/src/components/common/button/Button.module.scss
@@ -1,13 +1,13 @@
 @import "@/styles/theme";
 
 .button {
-  width: 100%;
   font-size: 1.6rem;
   border-radius: 3rem;
   border: none;
   height: 4.6rem;
   padding: 0 6rem;
-  font-weight: $regular;
+  font-weight: $bold;
+  transition: background-color 0.3s ease;
 }
 .orange_button {
   background-color: $main-color;
@@ -16,4 +16,8 @@
 .gray_button {
   background-color: $gray-100;
   color: $gray-400;
+}
+.red_button {
+  background-color: #e74141;
+  color: white;
 }

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -2,23 +2,26 @@ import style from "./Button.module.scss";
 
 type TBtnProps = {
   text: string;
-  color: "orange" | "gray";
+  color: "orange" | "gray" | "red";
+  className?: string;
+  onClick?: () => void;
 };
 
 export default function Button(props: TBtnProps) {
-  const { text, color } = props;
+  const { text, color, className, onClick } = props;
+
+  const baseClass =
+    color === "orange"
+      ? style.orange_button
+      : color === "gray"
+      ? style.gray_button
+      : style.red_button;
   return (
-    <>
-      {color === "orange" && (
-        <button className={`${style.orange_button} ${style.button}`}>
-          {text}
-        </button>
-      )}
-      {color === "gray" && (
-        <button className={`${style.gray_button} ${style.button}`}>
-          {text}
-        </button>
-      )}
-    </>
+    <button
+      className={`${style.button} ${baseClass} ${className}`}
+      onClick={onClick}
+    >
+      {text}
+    </button>
   );
 }

--- a/src/components/common/modal/LoginModal.module.scss
+++ b/src/components/common/modal/LoginModal.module.scss
@@ -1,24 +1,38 @@
 @import "@/styles/theme";
 
-.modal {
+.overlay {
   position: fixed;
-  top: 40%;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5); // 반투명 배경
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 999;
+}
+
+.modal {
+  position: relative;
+  padding: 3rem;
   background-color: white;
   width: 41.6rem;
   height: 22.5rem;
   box-shadow: $shadow;
   border-radius: 2rem;
-  z-index: 10;
+  z-index: 1000;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   gap: 2rem;
   font-size: 1.8rem;
+}
 
-  .close {
-    position: absolute;
-    top: 2rem;
-    right: 2rem;
-  }
+.close_button {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  cursor: pointer;
 }

--- a/src/components/common/modal/LoginModal.tsx
+++ b/src/components/common/modal/LoginModal.tsx
@@ -1,14 +1,23 @@
 import style from "./LoginModal.module.scss";
 import Close from "@public/Close.svg";
 
-export default function LoginModal() {
+type LoginModalProps = {
+  onClose: () => void;
+};
+
+export default function LoginModal({ onClose }: LoginModalProps) {
   return (
-    <>
-      <div className={`${style.modal}`}>
+    <div className={style.overlay} onClick={onClose}>
+      <div
+        className={style.modal}
+        onClick={(e) => e.stopPropagation()} // 모달 내부 클릭 시 닫히지 않게
+      >
         <div>로그인이 필요한 서비스 입니다</div>
         <img src="kakao_login.png" />
-        <Close className={`${style.close}`} />
+        <div onClick={onClose} className={style.close_button}>
+          <Close className={style.close} />
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/lib/fetchs/fetchRating.ts
+++ b/src/lib/fetchs/fetchRating.ts
@@ -13,8 +13,8 @@ export const postRating = async (cocktailId: string | string[], rating: number) 
     if (!response.ok) {
       throw new Error('리뷰 저장에 실패했습니다.');
     }
-
-    return;
+    const data = await response.json();
+    return data;
   } catch (error) {
     console.error("리뷰 저장 에러:", error);
     throw error;

--- a/src/lib/fetchs/fetchRating.ts
+++ b/src/lib/fetchs/fetchRating.ts
@@ -1,13 +1,13 @@
 
-export const postReview = async (cocktailId: string | string[], reviewText: string) => {
+export const postRating = async (cocktailId: string | string[], rating: number) => {
   try {
-    const response = await fetch(`http://localhost:3000/api/review/memo`, {
+    const response = await fetch(`http://localhost:3000/api/review/rating`, {
       method: 'POST',
       cache : "no-store",
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ cocktailId, reviewText }),
+      body: JSON.stringify({ cocktailId, rating }),
     });
 
     if (!response.ok) {
@@ -20,9 +20,9 @@ export const postReview = async (cocktailId: string | string[], reviewText: stri
     throw error;
   }
 };
-export const getReview = async (cocktailId: string | string[]) => {
+export const getRating = async (cocktailId: string | string[]) => {
   try {
-    const response = await fetch(`http://localhost:3000/api/review/memo?cocktailId=${cocktailId}`, {
+    const response = await fetch(`http://localhost:3000/api/review/rating?cocktailId=${cocktailId}`, {
       method: 'GET',
       cache : "no-store",
       headers: {

--- a/src/lib/fetchs/fetchReview.ts
+++ b/src/lib/fetchs/fetchReview.ts
@@ -13,8 +13,8 @@ export const postReview = async (cocktailId: string | string[], reviewText: stri
     if (!response.ok) {
       throw new Error('리뷰 저장에 실패했습니다.');
     }
-
-    return;
+    const data = await response.json();
+    return data;
   } catch (error) {
     console.error("리뷰 저장 에러:", error);
     throw error;

--- a/src/lib/fetchs/fetchReview.ts
+++ b/src/lib/fetchs/fetchReview.ts
@@ -20,6 +20,26 @@ export const postReview = async (cocktailId: string | string[], reviewText: stri
     throw error;
   }
 };
+export const deleteReview = async (cocktailId: string | string[]) => {
+  try {
+    const response = await fetch(`http://localhost:3000/api/review/memo?cocktailId=${cocktailId}`, {
+      method: 'DELETE',
+      cache : "no-store",
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    if (!response.ok) {
+      throw new Error('리뷰 삭제에 실패했습니다.');
+    }
+    return response; 
+  }
+  catch (error) {
+    console.error("리뷰 삭제 에러:", error);
+    throw error;
+  }
+}
+
 export const getReview = async (cocktailId: string | string[]) => {
   try {
     const response = await fetch(`http://localhost:3000/api/review/memo?cocktailId=${cocktailId}`, {

--- a/src/lib/store/memberStore.ts
+++ b/src/lib/store/memberStore.ts
@@ -1,26 +1,26 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-
-type Tmemo = {
-  cocktail_id: string;
-  memo_txt: string;
-  rating: number;
-};
+import { Tmemo } from "@/lib/types/TMemo";
 
 type TMemberStoreStore = {
   heart: string[];
   memo: Tmemo[];
-  setHeart: (data: any) => void;
-  setMemo: (data: any) => void;
+  setHeart: (data: string[] | ((prev: string[]) => string[])) => void;  
+  setMemo: (data: Tmemo[] | ((prev: Tmemo[]) => Tmemo[])) => void;
 };
-
 export const useMemberStore = create<TMemberStoreStore>()(
   persist(
     (set) => ({
       heart: [],
       memo: [],
-      setHeart: (data) => set({ heart: data }),
-      setMemo: (data) => set({ memo: data }),
+      setHeart: (data) =>
+        set((state) => ({
+          heart: typeof data === "function" ? data(state.heart) : data,
+        })),
+      setMemo: (data) =>
+        set((state) => ({
+          memo: typeof data === "function" ? data(state.memo) : data,
+        })),
     }),
     { name: "mamberStore-strage" }
   )

--- a/src/lib/types/TMemo.ts
+++ b/src/lib/types/TMemo.ts
@@ -1,5 +1,5 @@
 export type Tmemo = {
   cocktail_id: string;
-  memo_txt: string;
+  memo_txt?: string;
   rating: number;
 };

--- a/src/lib/types/TMemo.ts
+++ b/src/lib/types/TMemo.ts
@@ -1,0 +1,5 @@
+export type Tmemo = {
+  cocktail_id: string;
+  memo_txt: string;
+  rating: number;
+};


### PR DESCRIPTION
제가 어쩌다 보니 원기옥을 모으게 되어 죄송합니다..
수정 사항은 간략히만 적어두겠습니다!
- 기존 리뷰 존재 시 렌더링 & 수정, 저장 가능 ( db 및 zustand store 에 반영 )
- 기존 리뷰 없다면 리뷰 작성 후 저장 가능.
- 기존 별점 있다면 별점 그대로 보여줌. ( 별점 취소 가능, 별점 수정 가능 )
- TMemo 타입 types 폴더에 추가. => store 업데이트 하다가 함수 자체가 업데이트 되었어서 방지 작업 과정 중에 빼두었습니다.
- postReview 말고도 getReview, postRating, getRating api 코드 추가 및 그에 따른 fetch 함수 추가.
- 대부분의 fetch 함수에 cache: no-store 적용
- memberStore 에서 setMemo 및 setHeart 저장 로직 수정. => 위에서 얘기한 것처럼 함수표현식 자체가 저장되어버린 경우가 있어서 대비차 수정하였습니다.
- 리뷰의 "삭제" 버튼 및 기능도 추가하였습니다. "삭제"버튼 클릭 시 별점은 유지되며 리뷰텍스트만 삭제됩니다.
-  get 요청을 통해 받아온 데이터로 리렌더링 하던 방식을 post 응답의 데이터로 리렌더링 할 수 있도록 효율화 했습니다
- button 태그를 모두 Button 컴포넌트로 변경했습니다. ( 컴포넌트 구조 및 코드 수정 ) 
- 로그인 모달을 통해 로그인 권한 없음 알림 창을 띄웁니다. ( 로그인 모달 css, tsx 수정 )
- 상세페이지에 이모지 렌더링 하였습니다.