### PR TITLE
✨ [new features] 로그인 모달 부분 적용 & 창고페이지 코드 업데이트 & 상세페이지 오류 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import { Noto_Sans_KR } from "next/font/google";
 import "./globals.scss";
 import Header from "@/components/common/header/Herder";
+import LoginModal from "@/components/common/modal/LoginModal";
 import AuthSession from "@/app/AuthSession";
 import UpdateStore from "@/components/updateStore";
 
@@ -31,6 +32,7 @@ export default function RootLayout({
           {children}
           <Header></Header>
         </AuthSession>
+        <LoginModal />
       </body>
     </html>
   );

--- a/src/app/storage/Storage.tsx
+++ b/src/app/storage/Storage.tsx
@@ -7,28 +7,12 @@ import MemoCard from "@/components/common/card/MemoCard";
 import DropdownArrow from "@public/DropdownArrow.svg";
 import { useMemberStore } from "@/lib/store/memberStore";
 import { useCocktailStore } from "@/lib/store/cocktailStore";
-import { THeartItem } from "@/lib/types/THeart";
-import { TMemo } from "@/lib/types/TMemo";
 
-type StorageProps = {
-  heartList: THeartItem[];
-  memoList: TMemo[];
-};
-
-const Storage = ({ heartList, memoList }: StorageProps) => {
+const Storage = () => {
   const [activeTab, setActiveTab] = useState<string>("recorded");
   const [filterOption, setFilterOption] = useState<string>("별점순");
-  const { heart, memo, setHeart, setMemo } = useMemberStore();
+  const { heart, memo } = useMemberStore();
   const { cocktailList } = useCocktailStore();
-  const [hydrated, setHydrated] = useState(false);
-
-  useEffect(() => {
-    if (!hydrated) {
-      setHeart(heartList); // SSR 받은 heartList 로 zustand 초기화
-      setMemo(memoList); // SSR 받은 memoList 로 zustand 초기화
-      setHydrated(true); // 이제부터는 CSR 모드로
-    }
-  }, [heartList, memoList, setHeart, setMemo, hydrated]);
 
   const handleFilterChange = (value: string) => {
     console.log("Selected Filter:", value);

--- a/src/app/storage/page.tsx
+++ b/src/app/storage/page.tsx
@@ -5,11 +5,20 @@ import { authOptions } from "../api/auth/[...nextauth]/route";
 
 export default async function StoragePage() {
   const session = await getServerSession(authOptions);
-  const { heart, memo } = session?.user?.memberStore;
+
+  if (!session) {
+    return (
+      <div className="flex flex-col items-center justify-center h-screen">
+        <h1 className="text-2xl font-bold">
+          잘못된 접근 방식입니다. 로그인 후 이용해주세요.
+        </h1>
+      </div>
+    );
+  }
 
   return (
     <>
-      <Storage heartList={heart} memoList={memo} />
+      <Storage />
     </>
   );
 }

--- a/src/components/common/header/Herder.tsx
+++ b/src/components/common/header/Herder.tsx
@@ -5,17 +5,20 @@ import style from "./header.module.scss";
 import Search from "@public/Search.svg";
 import LoginBtn from "./LoginBtn";
 import { useSession } from "next-auth/react";
-import { useRouter, usePathname } from "next/navigation";
+import { useRouter } from "next/navigation";
+import { useModalStore } from "@/lib/store/modalStore";
 
 export default function Header() {
   const { data: session } = useSession();
+  const { open } = useModalStore();
+
   const memberName = session?.user?.name;
   console.log("🚨", session);
   const router = useRouter();
 
   const goToStorage = () => {
     if (!session) {
-      alert("로그인 후 이용해주세요.");
+      open();
     } else {
       if (!memberName) return;
       router.push("/storage");

--- a/src/components/common/modal/LoginModal.tsx
+++ b/src/components/common/modal/LoginModal.tsx
@@ -1,31 +1,31 @@
+"use client";
+
 import style from "./LoginModal.module.scss";
 import Close from "@public/Close.svg";
 import KakaoLoginButton from "@public/kakao_login.png";
+import { useModalStore } from "@/lib/store/modalStore";
 import { signIn } from "next-auth/react";
 import Image from "next/image";
 
-type LoginModalProps = {
-  onClose: () => void;
-};
+export default function LoginModal() {
+  const { isOpen, close } = useModalStore();
 
-export default function LoginModal({ onClose }: LoginModalProps) {
+  if (!isOpen) return null;
+
   return (
-    <div className={style.overlay} onClick={onClose}>
-      <div
-        className={style.modal}
-        onClick={(e) => e.stopPropagation()} // 모달 내부 클릭 시 닫히지 않게
-      >
-        <div>로그인이 필요한 서비스 입니다</div>
+    <div className={style.overlay} onClick={close}>
+      <div className={style.modal} onClick={(e) => e.stopPropagation()}>
+        <div>로그인이 필요한 서비스입니다</div>
 
         <Image
           src={KakaoLoginButton.src}
           alt="Kakao Login"
           onClick={() => signIn("kakao")}
-          width={200} // Replace with the actual width of your image
-          height={50} // Replace with the actual height of your image
+          width={200}
+          height={50}
         />
       </div>
-      <div onClick={onClose} className={style.close_button}>
+      <div onClick={close} className={style.close_button}>
         <Close className={style.close} />
       </div>
     </div>

--- a/src/lib/fetchs/fetchHeart.ts
+++ b/src/lib/fetchs/fetchHeart.ts
@@ -9,7 +9,6 @@ export const postHeart = async (heartList: THeartItem[]) => {
       },
       body: JSON.stringify(heartList),
     });
-    console.log("😍😎이게바로 heart",response);
     return response.json();
   } catch (error) {
     console.error("즐겨찾기 post 에러:", error);

--- a/src/lib/store/modalStore.ts
+++ b/src/lib/store/modalStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+type ModalStore = {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+};
+
+export const useModalStore = create<ModalStore>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
- 로그인 모달을 zustand 를 활용하여 어디서든 열 수 있도록 만들었습니다. LoginModal 컴포넌트는 layout.tsx 파일에 선언됩니다.
- 상세 페이지에서 emoji 와 base, flavor 매칭 코드 오류를 수정하였습니다. base 와 flavor 값이 undefined 일 때 includes() 함수를 실행할 수 없는 오류였습니다.
- 오류 수정 과정에서 base 와 flavor 가 여러개 ( 2개 이상 ) 인 칵테일도 있는데, 추후에 UI 수정을 하면 좋지 않을까 싶습니다.
- 창고 페이지에서 getServerSession 으로 가져온 유저별 heart, memo 칵테일을 사용하던 방식을 제거하고, 서버 컴포넌트에서는 잘못된 접근 방식 ( url 입력으로 접속 )을 알려주는 렌더링 코드만 추가하였습니다.