### PR TITLE
결국에 scrollRestoration 기능 때문에 SSR 버리고 최상단 클라이언트 컴포넌트에서 모든 칵테일 데이터를 zustand store 에 넣는 건에 대하여

### DIFF
--- a/src/app/mypage/Mypage.module.scss
+++ b/src/app/mypage/Mypage.module.scss
@@ -62,7 +62,7 @@
   box-shadow: $shadow;
   position: relative;
   &:hover {
-    background-color: rgb(255, 250, 238);
+    background-color: rgb(247, 242, 229);
     transition: 0.3s;
   }
 }

--- a/src/app/mypage/Mypage.module.scss
+++ b/src/app/mypage/Mypage.module.scss
@@ -61,6 +61,10 @@
   border-radius: 2rem;
   box-shadow: $shadow;
   position: relative;
+  &:hover {
+    background-color: rgb(255, 250, 238);
+    transition: 0.3s;
+  }
 }
 
 .delete_account {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,11 +7,7 @@ import { getEmoji } from "@/lib/fetchs/fetchEmoji";
 import EmojiClient from "@/components/render/EmojiClient";
 
 export default async function Home() {
-  const response25 = await getCocktail(25, 0);
-  const initialCocktails = response25.cocktails;
-  const totalCocktailCount = response25.totalCount;
   const emoji = await getEmoji();
-
   return (
     <>
       <Navigation />
@@ -19,10 +15,7 @@ export default async function Home() {
       <div className={`${style.main_page}`}>
         <Top100 />
         <div>
-          <FilterSection
-            initialCocktails={initialCocktails}
-            totalCocktailCount={totalCocktailCount}
-          />
+          <FilterSection />
         </div>
       </div>
     </>

--- a/src/app/storage/Storage.tsx
+++ b/src/app/storage/Storage.tsx
@@ -80,7 +80,7 @@ const Storage = () => {
       return 0;
     });
   }, [cocktailCardList, filterOption]);
-
+  console.log(style);
   return (
     <div className={style.container}>
       {/* 탭 메뉴 */}
@@ -123,30 +123,38 @@ const Storage = () => {
 
       {/* 렌더링 영역 */}
       <div className={style.card_container}>
-        {activeTab === "recorded" && memoCocktailCardList
-          ? sortedMemoList.map((cocktail) => (
-              <MemoCard
-                key={cocktail._id}
-                id={cocktail._id}
-                name={cocktail.name.ko}
-                img_url={cocktail.img}
-                memo={
-                  memo.find((item) => item.cocktail_id === cocktail._id)
-                    ?.memo_txt
-                }
-                rating={
-                  memo.find((item) => item.cocktail_id === cocktail._id)?.rating
-                }
-              />
-            ))
-          : sortedMemoList.map((cocktail) => (
-              <Card
-                key={cocktail._id}
-                id={cocktail._id}
-                name={cocktail.name}
-                img_url={cocktail.img}
-              />
-            ))}
+        {sortedMemoList.length === 0 ? (
+          <div className={`${style.empty_message}`}>
+            <h3>
+              저장된 칵테일이 없습니다. 칵테일마다 리뷰와 별점을 남겨주세요
+            </h3>
+          </div>
+        ) : // 필터링한 칵테일 카드들 렌더
+        activeTab === "recorded" && memoCocktailCardList ? (
+          sortedMemoList.map((cocktail) => (
+            <MemoCard
+              key={cocktail._id}
+              id={cocktail._id}
+              name={cocktail.name.ko}
+              img_url={cocktail.img}
+              memo={
+                memo.find((item) => item.cocktail_id === cocktail._id)?.memo_txt
+              }
+              rating={
+                memo.find((item) => item.cocktail_id === cocktail._id)?.rating
+              }
+            />
+          ))
+        ) : (
+          sortedMemoList.map((cocktail) => (
+            <Card
+              key={cocktail._id}
+              id={cocktail._id}
+              name={cocktail.name}
+              img_url={cocktail.img}
+            />
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/app/storage/Storage.tsx
+++ b/src/app/storage/Storage.tsx
@@ -20,7 +20,6 @@ const Storage = () => {
   const [activeTab, setActiveTab] = useState<string>(defaultTab);
 
   const handleFilterChange = (value: string) => {
-    console.log("Selected Filter:", value);
     setFilterOption(value);
   };
 
@@ -40,9 +39,6 @@ const Storage = () => {
         : favoriteCocktailCardList,
     [activeTab, memo, heart, cocktailList]
   );
-  useEffect(() => {
-    console.log("칵테일 정렬 리스트 확인용", sortedMemoList);
-  }, [filterOption, activeTab]);
 
   // 최신순 칵테일 카드 배열
   const sortedMemoList = useMemo(() => {
@@ -80,7 +76,6 @@ const Storage = () => {
       return 0;
     });
   }, [cocktailCardList, filterOption]);
-  console.log(style);
   return (
     <div className={style.container}>
       {/* 탭 메뉴 */}

--- a/src/app/storage/storage.module.scss
+++ b/src/app/storage/storage.module.scss
@@ -58,13 +58,25 @@
   background-color: transparent;
   cursor: pointer;
   min-width: 8rem; /* 드롭다운 리스트 최소 너비 */
-    option {
-      text-align: center;
-    }
+}
+.select option {
+  text-align: center;
 }
 .card_container {
   display: flex;
   flex-wrap: wrap;
+  width: 100%;
   gap: 2rem;
   padding: 1rem 2rem 1rem 0;
+}
+.empty_message {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  font-size: 2rem;
+  h3{
+    color: $gray-200
+  }
 }

--- a/src/components/common/header/Herder.tsx
+++ b/src/components/common/header/Herder.tsx
@@ -15,12 +15,20 @@ export default function Header() {
   const memberName = session?.user?.name;
   const router = useRouter();
 
-  const goToStorage = () => {
-    if (!session) {
-      openLoginModal();
+  const linkToMenu = (name: string) => {
+    if (name === "storage") {
+      if (!session) {
+        openLoginModal();
+      } else {
+        if (!memberName) return;
+        router.push(`/${name}`);
+      }
     } else {
-      if (!memberName) return;
-      router.push("/storage");
+      if (!session) {
+        console.log("로그인 해주세요");
+      }
+      console.log("검색이동");
+      router.push(`/${name}`);
     }
   };
 
@@ -34,13 +42,17 @@ export default function Header() {
             <div>모히또에서 몰디브 한 잔</div>
           </Link>
           <ul>
-            <Link href="/find">
-              <li className={`${style.search_btn}`}>
-                <Search className={`${style.search_svg}`} />
-                <div>칵테일 검색</div>
-              </li>
-            </Link>
-            <li className={`${style.storage_btn}`} onClick={goToStorage}>
+            <li
+              onClick={() => linkToMenu("find")}
+              className={`${style.search_btn}`}
+            >
+              <Search className={`${style.search_svg}`} />
+              <div>칵테일 검색</div>
+            </li>
+            <li
+              className={`${style.storage_btn}`}
+              onClick={() => linkToMenu("storage")}
+            >
               내 칵테일 창고
             </li>
           </ul>

--- a/src/components/main/FilterSection.tsx
+++ b/src/components/main/FilterSection.tsx
@@ -5,7 +5,6 @@ import { getCocktail } from "@/lib/fetchs/fetchCocktail";
 import { TCocktail } from "@/lib/types/TCocktail";
 import { useOffsetStore } from "@/lib/store/offsetStore";
 import { useCocktailStore } from "@/lib/store/cocktailStore";
-import { useSmartScrollRestore } from "@/lib/hooks/useScrollRestoration";
 
 import style from "./FilterSection.module.scss";
 import Filter from "./filter/Filter";
@@ -16,8 +15,6 @@ export default function FilterSection() {
   const [localCocktailList, setLocalCocktailList] = useState<TCocktail[]>([]);
   const { offset, setOffset } = useOffsetStore();
   const isLoading = useRef(false);
-
-  // useSmartScrollRestore();
 
   //스크롤 바가 아래로 내려가면 실행될 loadMore 함수, 이 메서드는 cocktailList 컴포넌트로 넘겨준다.
   const loadMore = useCallback(async () => {

--- a/src/components/main/cocktailList/CocktailList.tsx
+++ b/src/components/main/cocktailList/CocktailList.tsx
@@ -25,7 +25,8 @@ export default function CocktailList({
   });
 
   useEffect(() => {
-    if (!observerRef.current) return;
+    const target = observerRef.current;
+    if (!target) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -33,18 +34,15 @@ export default function CocktailList({
           loadMore();
         }
       },
-      { threshold: 1.0 }
+      { threshold: 0.3 }
     );
 
-    observer.observe(observerRef.current);
+    observer.observe(target);
 
     return () => {
-      if (observerRef.current) {
-        observer.unobserve(observerRef.current);
-      }
+      observer.unobserve(target);
     };
   }, [loading, loadMore]);
-
   return (
     <div className={style.cocktailList}>
       {cocktailList.map((cocktail) => (

--- a/src/components/main/filter/Filter.tsx
+++ b/src/components/main/filter/Filter.tsx
@@ -12,7 +12,7 @@ import { filterList } from "@/lib/mokdata/filterList";
 export default function Filter() {
   //zustand 상태관리
   const { emojiList } = useEmojiStore();
-  console.log(emojiList);
+  // console.log(emojiList);
 
   return (
     <div className={`${style.filter_box}`}>
@@ -21,7 +21,7 @@ export default function Filter() {
         <h3>테이스팅 노트</h3>
         <div className={`${style.item_wrap}`}>
           {filterList.tasting.map((item) => (
-            <label>
+            <label key={item.name}>
               <input type="checkbox" />
               <div className={style.checkbox_content}>
                 <img
@@ -42,7 +42,7 @@ export default function Filter() {
         <h3>베이스</h3>
         <div className={`${style.item_wrap}`}>
           {filterList.base.map((item) => (
-            <label>
+            <label key={item.name}>
               <input type="checkbox" />
               <div className={style.checkbox_content}>
                 <img

--- a/src/components/updateStore.ts
+++ b/src/components/updateStore.ts
@@ -3,10 +3,12 @@
 import { useMemberStore } from "@/lib/store/memberStore";
 import { useSession } from "next-auth/react";
 import { useEffect } from "react";
+import { useCocktailStore } from "@/lib/store/cocktailStore";
 
 export default function UpdateStore() {
-  const { data: session, status, update } = useSession();
-  const { setHeart, setMemo, heart, memo } = useMemberStore();
+  const { data: session, update } = useSession();
+  const { setHeart, setMemo } = useMemberStore();
+  const { cocktailList, fetchAllCocktails } = useCocktailStore();
 
   useEffect(() => {
     if (!session?.user || session.user.firstLogin) return; //세션이 없거나 firstLogin이 true면 실행 안함
@@ -17,6 +19,13 @@ export default function UpdateStore() {
     setMemo(sessionMemo);
     update({ ...session, user: { ...session.user, firstLogin: true } });
   }, [session?.user?.firstLogin]);
+
+  // 모든 칵테일을 불러옵니다.
+  useEffect(() => {
+    if (cocktailList.length === 0) {
+        fetchAllCocktails();
+    }
+  }, [cocktailList, fetchAllCocktails]);
 
   return null;
 }

--- a/src/lib/hooks/useLockButton.ts
+++ b/src/lib/hooks/useLockButton.ts
@@ -15,7 +15,7 @@ export const useLockButton = (key: string) => {
         await fn();
       } finally {
         // 1초 대기
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await new Promise((resolve) => setTimeout(resolve, 500));
         unlock(key);
       }
     },

--- a/src/lib/store/cocktailStore.ts
+++ b/src/lib/store/cocktailStore.ts
@@ -6,18 +6,19 @@ import { TCocktail } from "@/lib/types/TCocktail";
 // 모든 칵테일을 불러옵니다.
 type TCocktailStore = {
   cocktailList: TCocktail[];
+  totalCount: number;
   fetchAllCocktails: () => Promise<void>;
 };
 
-//모든 칵테일 저장 코드
 export const useCocktailStore = create<TCocktailStore>((set, get) => ({
   cocktailList: [],
+  totalCount: 0,
 
   fetchAllCocktails: async () => {
     const { cocktailList } = get();
     if (cocktailList.length > 0) return; 
     const response = await getCocktail(0, 0); 
-    set({ cocktailList: response.cocktails });
+    set({ cocktailList: response.cocktails, totalCount: response.totalCount });
   },
 }));
 


### PR DESCRIPTION
결국에는... SSR 로 렌더링 하는 칵테일 데이터들을 모두 폐기하였습니다.
현재 칵테일 카드들은 모두 클라이언트 측에서 받아와 가공하여 사용 중입니다.
그 이유는, 기존 SSR 이라고 사용하던 page.tsx ( 최상단 서버 컴포넌트 ) 에서 SSR 의 장점 중 하나인 SEO 최적화를 할 수 있는 유의미한 데이터가 하나도 렌더링 되고 있지 않았기 때문에 부담없이 변경 가능하였습니다.
만약 SSR 로 모든 칵테일 카드들을 렌더링하는 페이지가 구축되어있었다면 이렇게 바꿀 수 없었겠지만, 
이번 scrollRestoration 기능을 위해 이게 맞나 싶어 바꾸게 되었습니다.
이전에 발생하던 스크롤 위치 복원 안되는 문제와 칵테일 카드들의 렌더링 문제 모두 SSR 일때 사용하던 useState 때문이었습니다.
useState 에 렌더링 할 칵테일 데이터를 담고 있었는데, 이 useState 는 페이지를 벗어나게 되면 그 순간 사라지는 데이터이기 때문에 카드들이 렌더링되지 않고 있던 것이었습니다. 
그 와중에 브라우저가 스크롤 복원을 하려 하니 카드는 충분히 렌더링 되지 않은 상태에서 엉뚱한 위치로 복원하는 문제였던 것입니다.
어찌되었건, SSR 을 정말 하고 싶었지만, 현재 칵테일 데이터 양과 스크롤 복원의 편의성을 고려하여 칵테일 데이터는 클라이언트 측에서 받아오는 것으로 구현하였습니다.
