### PR TITLE
프로필 모달 반응형 설정 및 이모지 이미지로 변환

### DIFF
--- a/src/app/mypage/Mypage.module.scss
+++ b/src/app/mypage/Mypage.module.scss
@@ -7,11 +7,12 @@
   align-items: center;
 }
 .profile_image {
-  height: 16rem;
+  height: 8rem;
   font-size: 11rem;;
 }
 .nickname {
   margin-bottom: 2rem;
+  
   h1 {
     font-weight: $light;
   }
@@ -69,7 +70,7 @@
 }
 
 .delete_account {
-  margin: 7rem;
+  margin-top: 5rem;
   border-radius: 10rem;
   cursor: pointer;
   h4 {

--- a/src/app/mypage/MypageClient.tsx
+++ b/src/app/mypage/MypageClient.tsx
@@ -50,7 +50,10 @@ export default function MypageClient() {
       <Navigation />
       <div>
         {profileImageState ? (
-          <p className={`${style.profile_image}`}>{profileImageState}</p>
+          <img
+            src={profileImageState}
+            className={`${style.profile_image}`}
+          ></img>
         ) : (
           <Person className={`${style.profile_image}`} />
         )}

--- a/src/components/common/modal/profileSettingModal.module.scss
+++ b/src/components/common/modal/profileSettingModal.module.scss
@@ -19,8 +19,8 @@
   flex-direction: column;
   position: relative;
   background-color: white;
-  width: 40em;
-  height: 95vh;
+  width: 50rem;
+  height: 80vh;
   box-shadow: $shadow;
   border-radius: 5%;
   font-size: 1.8rem;
@@ -44,8 +44,6 @@
     background-color: $gray_100;
 
   }
-  .modal_bottom {
-  }
   .profile_title {
     font-size: 2rem;
     font-weight: 700;
@@ -53,28 +51,26 @@
   }
 
   .profile_image {
-    width: 20rem;
-    height: 20rem;
-    border-radius: 55%;
+    width: 18rem;
+    height: 18rem;
+    border-radius: 50%;
     background-color: white;
-    padding: 3rem;
+    padding: 1rem;
     overflow: hidden;
+    display: flex;
     justify-content: center;
     align-items: center;
     
-    svg, p {
-      width: 100%;
-      height: 100%;
-      text-align: center;
-      font-size: 9rem;
-      object-fit: cover;
+    svg, img {
+      width: 8rem;
+      height: 8rem;
     }
   }
 }
 .confirm_button {
   position: absolute;
   top: 2rem;
-  left: 2rem;
+  right: 2rem;
   padding: 0.2rem !important;
   width: 9rem;
   font-weight: $medium !important;
@@ -88,10 +84,11 @@
 .close_button {
   position: absolute;
   top: 2rem;
-  right: 2rem;
+  left: 2rem;
   padding: 0.2rem !important;
   width: 9rem;
   font-weight: $medium !important;
+  background-color: $gray-300 !important;
   cursor: pointer;
   &:hover {
     background-color: rgb(253, 178, 38);

--- a/src/components/common/modal/profileSettingModal.tsx
+++ b/src/components/common/modal/profileSettingModal.tsx
@@ -96,6 +96,12 @@ export default function ProfileSettingModal({
         <div className={`${style.modal_inner}`}>
           <div className={`${style.modal_upper}`}>
             <Button
+              text="취소"
+              color="red"
+              className={`${style.close_button}`}
+              onClick={handleCancelProfile}
+            ></Button>
+            <Button
               text="완료"
               color="orange"
               className={`${style.confirm_button}`}
@@ -103,18 +109,12 @@ export default function ProfileSettingModal({
                 handlesaveProfile(event, nicknameLocal, profileImageLocal)
               }
             ></Button>
-            <Button
-              text="취소"
-              color="red"
-              className={`${style.close_button}`}
-              onClick={handleCancelProfile}
-            ></Button>
             <h1 className={`${style.profile_title}`}>프로필 설정</h1>
             <div className={style.profile_image}>
               {profileImageLocal ? (
-                <p>{profileImageLocal}</p>
+                <img src={profileImageLocal} alt="profile Image"></img>
               ) : profileImage ? (
-                <p>{profileImage}</p>
+                <img src={profileImage}></img>
               ) : (
                 <Person />
               )}
@@ -154,7 +154,7 @@ export default function ProfileSettingModal({
                   </div>
                   <p
                     className={`${
-                      nicknameLocal.length >= 20
+                      nicknameLocal.length >= 15
                         ? style.nickname_warning
                         : style.nickname_none
                     }`}
@@ -165,9 +165,7 @@ export default function ProfileSettingModal({
               )}
             </div>
           </div>
-          <div className={`${style.modal_bottom}`}>
-            <EmojiPickerUI setProfileImageLocal={setProfileImageLocal} />
-          </div>
+          <EmojiPickerUI setProfileImageLocal={setProfileImageLocal} />
         </div>
       </div>
     </div>

--- a/src/components/emoji_picker/EmojiPicker.tsx
+++ b/src/components/emoji_picker/EmojiPicker.tsx
@@ -11,16 +11,15 @@ export default function EmojiPickerUI({
   setProfileImageLocal,
 }: EmojiPickerProps) {
   const handleEmojiClick = (emojiData: EmojiClickData, event: MouseEvent) => {
-    console.log(emojiData.emoji, "이모지 클릭됨");
-    setProfileImageLocal(emojiData.emoji);
+    setProfileImageLocal(emojiData.imageUrl);
   };
   return (
-    <div>
+    <div style={{ width: "100%", maxWidth: "490px" }}>
       <EmojiPicker
         onEmojiClick={handleEmojiClick}
-        emojiStyle={EmojiStyle.TWITTER} // 이모지 스타일 설정
-        width={700}
-        height={400} // 이모지 피커의 너비 설정
+        emojiStyle={EmojiStyle.APPLE} // 이모지 스타일 설정
+        width={490}
+        height={350} // 이모지 피커의 너비 설정
         previewConfig={{ showPreview: false }} // 이모지 미리보기 비활성화
       />
     </div>

--- a/src/components/top100/Top100.tsx
+++ b/src/components/top100/Top100.tsx
@@ -72,6 +72,31 @@ export default function Top100() {
                   : e.realIndex + 2
               )
             }
+            breakpoints={{
+              // 0px 이상에서는 1개
+              0: {
+                slidesPerView: 1,
+                spaceBetween: 10,
+              },
+              // 640px 이상(태블릿)
+              640: {
+                slidesPerView: 2,
+                spaceBetween: 15,
+              },
+              // 1024px 이상(데스크탑)
+              1024: {
+                slidesPerView: 3,
+                spaceBetween: 30,
+              },
+              1460: {
+                slidesPerView: 4,
+                spaceBetween: 30,
+              },
+              1700: {
+                slidesPerView: 5,
+                spaceBetween: 30,
+              },
+            }}
             onSwiper={(swiper) => setSwiper(swiper)}
           >
             {/* top100 랜덤 칵테일 카드 렌더링 부분 */}


### PR DESCRIPTION
- p 태그로 렌더링하던 이모지를 img 태그로 렌더링 할 수 있도록 변환하였습니다.
- 프로필 모달의 크기를 훨씬 작게 수정하였고, 반응형으로 ( 워낙 기본 사이즈가 작아 크게 효과 없음 ) 동작합니다.
- "취소" 와 "완료" 의 위치를 바꾸고, "취소" 버튼의 배경색을 변경하였습니다.
-  렌더링되던 이모지의 크기를 8rem 으로 수정하여 깨져보이지 않게 렌더링 ( 작아서 깨진 줄 모르게 ) 할 수 있습니다.



