### PR TITLE
🎨 [styling] #88 반응형 모바일 가로 추가 + isMobile 커스텀 훅

### DIFF
--- a/src/lib/hooks/useIsMobile.ts
+++ b/src/lib/hooks/useIsMobile.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export default function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    setIsMobile(/Android|iPhone|iPod|Mobile/i.test(navigator.userAgent));
+  }, []);
+
+  console.log("😈", isMobile);
+  return isMobile;
+}

--- a/src/lib/hooks/useIsMobile.ts
+++ b/src/lib/hooks/useIsMobile.ts
@@ -3,10 +3,17 @@ import { useEffect, useState } from "react";
 export default function useIsMobile() {
   const [isMobile, setIsMobile] = useState(false);
 
+  const checkMobile = () => {
+    if (
+      /Android|iPhone|iPod|Mobile/i.test(navigator.userAgent) ||
+      window.matchMedia("(max-width: 575px)").matches
+    )
+      setIsMobile(true);
+  };
+
   useEffect(() => {
-    setIsMobile(/Android|iPhone|iPod|Mobile/i.test(navigator.userAgent));
+    checkMobile();
   }, []);
 
-  console.log("😈", isMobile);
   return isMobile;
 }

--- a/src/styles/_mixin.scss
+++ b/src/styles/_mixin.scss
@@ -1,8 +1,14 @@
-@import "@/styles/theme";
+// @import "@/styles/theme";
+$mobile: 575px;
+$mobile-landscape: 932px; //아이폰 14프로맥스 기준
+$tablet: 720px;
+$laptop: 1024px;
+$pc: 1440px;
 
 @mixin respond($breakpoint) {
   @if $breakpoint == mobile {
-    @media (max-width: $mobile) {
+    @media (max-width: $mobile) and (orientation: portrait),
+      (max-width: $mobile-landscape) and (orientation: landscape) {
       @content;
     }
   } @else if $breakpoint == tablet {
@@ -13,8 +19,7 @@
     @media (min-width: $tablet) and (max-width: #{$pc - 1px}) {
       @content;
     }
-  } 
-  @else if $breakpoint == pc {
+  } @else if $breakpoint == pc {
     @media (min-width: $pc) {
       @content;
     }

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -17,9 +17,3 @@ $light: 300;
 $regular: 400;
 $medium: 500;
 $bold: 700;
-
-//반응형 width
-$mobile: 575px;
-$tablet: 720px;
-$laptop: 1024px; 
-$pc: 1440px;


### PR DESCRIPTION
1. mixin에 모바일 가로 사이즈를 추가했습니다!
그리고 기기별 사이즈 코드를 _theme 애서 _mixin 으로 옮겼어요!

2. useIsMobile 커스텀 훅을 만들었습니다!
하단 메뉴바 만드실 때 활용하실 수 있을것 같아요
컴포넌트에서 사용시
`import useIsMobile from "@/lib/hooks/useIsMobile";`
`const isMobile = useIsMobile();`
이렇게 쓰시면 됩니당