### PR TITLE
모바일 필터 구현

### DIFF
--- a/src/app/find/find.module.scss
+++ b/src/app/find/find.module.scss
@@ -3,10 +3,12 @@
 
 .body {
   display: flex;
+  justify-content: center;
   flex-direction: column;
   width: 65vw;
+  margin: 0 auto;
   scroll-behavior: smooth;
-  
+
   // 📱 모바일
   @include respond(mobile) {
     width: 90vw !important;
@@ -23,7 +25,4 @@
   grid-template-rows: 250px;
   place-items: center;
   margin-bottom: 6rem;
-
-
-
 }

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -19,11 +19,6 @@ html {
   }
 }
 
-body {
-  font-size: 1.6rem;
-  margin-top: 7rem; //헤더크기 만큼 내려옴
-}
-
 * {
   margin: 0;
   padding: 0;
@@ -35,7 +30,7 @@ body {
 }
 
 body {
-  display: flex;
-  justify-content: center;
+  font-size: 1.6rem;
+  margin-top: 7rem; //헤더크기 만큼 내려옴
   height: 100vh;
 }

--- a/src/components/main/FilterSection.module.scss
+++ b/src/components/main/FilterSection.module.scss
@@ -5,7 +5,7 @@
   height: 110rem;
   margin-bottom: 10rem;
   text-wrap: nowrap;
-  padding-top: 10rem;
+  padding-top: 7rem;
 
   h1 {
     width: fit-content;
@@ -20,9 +20,7 @@
     grid-template-columns: 1fr 2.5fr;
     column-gap: 2rem;
     width: 100%;
-    padding-top: 2rem;
     // overflow: auto;
-    top: 7rem;
   }
 
   //pc 필터
@@ -37,8 +35,8 @@
     flex-direction: column;
     justify-items: center;
     position: sticky;
+    top: 7rem;
     left: 0rem;
-    top: 0rem;
   }
 
   //모바일

--- a/src/components/main/FilterSection.module.scss
+++ b/src/components/main/FilterSection.module.scss
@@ -1,11 +1,11 @@
 @import "@/styles/theme";
 
-
 .filter_section {
   width: 98vw;
   height: 110rem;
   margin-bottom: 10rem;
   text-wrap: nowrap;
+  padding-top: 10rem;
 
   h1 {
     width: fit-content;
@@ -20,11 +20,91 @@
     grid-template-columns: 1fr 2.5fr;
     column-gap: 2rem;
     width: 100%;
-    padding: 0;
-  }
-  .fitler_wrap {
     padding-top: 2rem;
+    // overflow: auto;
+    top: 7rem;
   }
+
+  //pc 필터
+  .fitler_wrap {
+    box-shadow: $shadow;
+    border-radius: 0 2rem 2rem 0;
+    width: 42rem;
+    height: 100vh;
+    padding: 0rem 5rem;
+    background-color: white;
+    display: flex;
+    flex-direction: column;
+    justify-items: center;
+    position: sticky;
+    left: 0rem;
+    top: 0rem;
+  }
+
+  //모바일
+  .filter_btn {
+    position: fixed;
+    z-index: 4;
+    width: 100vw;
+    height: 6rem;
+    bottom: 7rem;
+    background-color: white;
+    border: none;
+    box-shadow: $shadow;
+    border-radius: 4rem 4rem 0 0;
+    font-size: 2.2rem;
+    font-weight: $bold;
+    color: $main-color;
+    cursor: pointer;
+
+    transition: opacity 0.3s;
+    opacity: 1;
+    //버튼 클릭시
+    &.hide {
+      opacity: 0;
+      pointer-events: none;
+    }
+  }
+  .filter_modal {
+    background-color: white;
+    z-index: 4;
+    width: 100vw;
+    position: fixed;
+    bottom: 7rem;
+    opacity: 0;
+    box-shadow: $shadow;
+    border-radius: 4rem 4rem 0 0;
+    // 애니메이션
+    transform: translateY(100%);
+    transition: transform 0.35s cubic-bezier(0.58, 0.93, 0.66, 1), opacity 0.1s;
+
+    &.open {
+      transform: translateY(0);
+      opacity: 1;
+    }
+
+    .modal_header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 2rem 4rem 0 4rem;
+    }
+    .title {
+      font-size: 3.4rem;
+      font-weight: $bold;
+      color: $main-color;
+    }
+    .close_btn {
+      position: relative;
+      right: 0em;
+      cursor: pointer;
+    }
+
+    .modal_fitler_wrap {
+      padding: 0rem 7rem;
+    }
+  }
+
   .card_wrap {
     overflow: visible;
     width: 100%;

--- a/src/components/main/FilterSection.tsx
+++ b/src/components/main/FilterSection.tsx
@@ -10,6 +10,8 @@ import Filter from "./filter/Filter";
 import CocktailList from "@/components/main/cocktailList/CocktailList";
 import { useFilterValueStore } from "@/lib/store/filterValueStore";
 import { TCocktail } from "@/lib/types/TCocktail";
+import useIsMobile from "@/lib/hooks/useIsMobile";
+import Close from "@public/Close.svg";
 
 export default function FilterSection() {
   const { cocktailList, totalCount } = useCocktailStore();
@@ -21,11 +23,17 @@ export default function FilterSection() {
     resetFilter,
     filterClicked,
     setFilterClicked,
+    viewCocktailList,
+    setViewCocktailList,
   } = useFilterValueStore();
   const { offset, setOffset } = useOffsetStore();
   const isLoading = useRef(false);
+  const isMobile = useIsMobile();
 
   const [visibleCocktails, setVisibleCocktails] = useState<TCocktail[]>([]);
+  const [filterOpen, setFilterOpen] = useState(false);
+
+  console.log("🤖", isMobile);
 
   //필터링
   const handleFilter = () => {
@@ -43,17 +51,18 @@ export default function FilterSection() {
 
       return matchFlavor && matchBase && matchBooziness && matchSweetness;
     });
-    setVisibleCocktails(filterdCocktailList);
+    setViewCocktailList(filterdCocktailList);
     setFilterClicked(true);
+    isMobile && setFilterOpen(false);
   };
 
   const handelReset = () => {
-    setVisibleCocktails(cocktailList.slice(0, offset));
+    setViewCocktailList(cocktailList.slice(0, offset));
     resetFilter();
   };
 
   useEffect(() => {
-    if (!filterClicked) setVisibleCocktails(cocktailList.slice(0, offset));
+    if (!filterClicked) setViewCocktailList(cocktailList.slice(0, offset));
   }, [cocktailList, offset, filterClicked]);
 
   // 무한 스크롤
@@ -106,24 +115,54 @@ export default function FilterSection() {
 
   return (
     <div className={`${style.filter_section}`}>
-      <h1>Filter Section</h1>
       <div className={`${style.filter_card_wrap}`}>
-        <div className={`${style.fitler_wrap}`}>
-          <Filter onSearch={handleFilter} onReset={handelReset} />
-        </div>
+        {isMobile ? ( //mobile
+          <>
+            <button
+              className={`${style.filter_btn} ${filterOpen ? style.hide : ""}`}
+              onClick={() => setFilterOpen(true)}
+            >
+              Filter
+            </button>
+            <div
+              className={`${style.filter_modal} ${
+                filterOpen ? style.open : ""
+              } `}
+            >
+              <div className={`${style.modal_header}`}>
+                <span className={`${style.title}`}>Filter</span>
+                <div
+                  className={`${style.close_btn}`}
+                  onClick={() => setFilterOpen(false)}
+                >
+                  <Close></Close>
+                </div>
+              </div>
+              <div className={`${style.modal_fitler_wrap}`}>
+                <Filter onSearch={handleFilter} onReset={handelReset} />
+              </div>
+            </div>
+          </>
+        ) : (
+          //pc
+          <div className={`${style.fitler_wrap}`}>
+            <Filter onSearch={handleFilter} onReset={handelReset} />
+          </div>
+        )}
+
         <div className={`${style.card_wrap}`}>
           <CocktailList
-            cocktailList={visibleCocktails}
+            cocktailList={viewCocktailList}
             loadMore={loadMore}
             loading={isLoading.current}
             inputValue=""
             selectValue=""
             clickedHashtag=""
           />
-          {visibleCocktails.length === 0 ? (
+          {viewCocktailList.length === 0 ? (
             <p className={style.nomore_data}>🍹잠시만 기다려주세요.🍹</p>
           ) : (
-            visibleCocktails.length >= totalCount && (
+            viewCocktailList.length >= totalCount && (
               <p className={style.nomore_data}>
                 🍹모든 칵테일을 불러왔습니다🍹
               </p>

--- a/src/components/main/FilterSection.tsx
+++ b/src/components/main/FilterSection.tsx
@@ -9,7 +9,6 @@ import style from "./FilterSection.module.scss";
 import Filter from "./filter/Filter";
 import CocktailList from "@/components/main/cocktailList/CocktailList";
 import { useFilterValueStore } from "@/lib/store/filterValueStore";
-import { TCocktail } from "@/lib/types/TCocktail";
 import useIsMobile from "@/lib/hooks/useIsMobile";
 import Close from "@public/Close.svg";
 
@@ -30,10 +29,7 @@ export default function FilterSection() {
   const isLoading = useRef(false);
   const isMobile = useIsMobile();
 
-  const [visibleCocktails, setVisibleCocktails] = useState<TCocktail[]>([]);
   const [filterOpen, setFilterOpen] = useState(false);
-
-  console.log("🤖", isMobile);
 
   //필터링
   const handleFilter = () => {

--- a/src/components/main/FilterSection.tsx
+++ b/src/components/main/FilterSection.tsx
@@ -141,8 +141,11 @@ export default function FilterSection() {
           </>
         ) : (
           //pc
-          <div className={`${style.fitler_wrap}`}>
-            <Filter onSearch={handleFilter} onReset={handelReset} />
+          <div>
+            <h1>Filter</h1>
+            <div className={`${style.fitler_wrap}`}>
+              <Filter onSearch={handleFilter} onReset={handelReset} />
+            </div>
           </div>
         )}
 

--- a/src/components/main/filter/Filter.module.scss
+++ b/src/components/main/filter/Filter.module.scss
@@ -2,20 +2,6 @@
 @import "@/styles/mixin";
 
 .filter_box {
-  box-shadow: $shadow;
-  border-radius: 0 2rem 2rem 0;
-  width: 42rem;
-  height: 100vh;
-  padding: 0rem 5rem;
-  background-color: white;
-  display: flex;
-  flex-direction: column;
-  justify-items: center;
-
-  position: sticky;
-  left: 0rem;
-  top: 7rem;
-
   .tasting_wrap {
     width: 100%;
   }
@@ -28,6 +14,10 @@
     font-size: 1.8rem;
     font-weight: $bold;
     user-select: none;
+
+    @include respond(mobile) {
+      margin-top: 2.2rem;
+    }
   }
 
   .item_wrap {
@@ -35,6 +25,10 @@
     display: grid;
     grid-template-columns: repeat(2, auto);
     gap: 2rem 3rem;
+
+    @include respond(mobile) {
+      gap: 1rem 2rem;
+    }
   }
 
   label {
@@ -102,12 +96,30 @@
     align-items: center;
     gap: 1rem;
 
-    .return_svg {
-      // height: 1.4rem;
-    }
-
     .return_txt {
       color: $main-color;
     }
+  }
+
+  @include respond(mobile) {
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 2rem;
+
+    .search_btn {
+      width: 20rem;
+    }
+
+    .return_btn {
+      margin: 0rem;
+    }
+  }
+}
+
+@include respond(mobile) {
+  .filter_box {
+    position: relative;
   }
 }

--- a/src/components/main/filter/Filter.module.scss
+++ b/src/components/main/filter/Filter.module.scss
@@ -38,7 +38,6 @@
       display: none;
 
       &:checked + .checkbox_content {
-        // border: 0.1rem solid $main-color;
         box-shadow: 0rem 0rem 0.8rem rgba(255, 139, 7, 0.559);
       }
     }
@@ -48,7 +47,6 @@
       justify-content: center;
       align-items: center;
       box-shadow: $shadow;
-      // border: 0.2rem solid black;
       border-radius: 1rem;
       font-size: 1.4rem;
 
@@ -71,26 +69,30 @@
 }
 .slider_wrap {
   margin-top: 2rem;
+  width: 96%;
+  margin: 0 auto;
 }
 .sweet_wrap {
   width: 100%;
 }
 
 .btn_wrap {
+  display: flex;
   width: 100%;
-  margin-top: 4rem;
+  margin-top: 6rem;
+  align-items: center;
   justify-items: center;
+  justify-content: space-between;
 
   .search_btn {
     cursor: pointer;
     width: 100%;
     position: relative;
+    margin-left: 6rem;
   }
 
   .return_btn {
     cursor: pointer;
-    margin-top: 2rem;
-    padding: 0 1rem;
     color: $main-color;
     display: flex;
     align-items: center;
@@ -102,18 +104,10 @@
   }
 
   @include respond(mobile) {
-    display: flex;
-    flex-direction: row-reverse;
-    align-items: center;
-    justify-content: space-between;
     padding-bottom: 2rem;
 
     .search_btn {
       width: 20rem;
-    }
-
-    .return_btn {
-      margin: 0rem;
     }
   }
 }

--- a/src/components/main/filter/Filter.tsx
+++ b/src/components/main/filter/Filter.tsx
@@ -10,7 +10,6 @@ import { useEmojiStore } from "@/lib/store/emojiStore";
 import { useCocktailStore } from "@/lib/store/cocktailStore";
 import { useFilterValueStore } from "@/lib/store/filterValueStore";
 import { filterData } from "@/lib/mokdata/filterData";
-import { useState } from "react";
 
 type TFilter = {
   onSearch: () => void;
@@ -107,16 +106,16 @@ export default function Filter({ onSearch, onReset }: TFilter) {
       </div>
 
       <div className={`${style.btn_wrap}`}>
+        <div className={`${style.return_btn}`} onClick={onReset}>
+          <ReturnArrow className={`${style.return_svg}`} />
+          <span className={`${style.return_txt}`}>초기화</span>
+        </div>
         <Button
           className={`${style.search_btn}`}
           text="검색"
           color="orange"
           onClick={onSearch}
         ></Button>
-        <div className={`${style.return_btn}`} onClick={onReset}>
-          <ReturnArrow className={`${style.return_svg}`} />
-          <span className={`${style.return_txt}`}>초기화</span>
-        </div>
       </div>
     </div>
   );

--- a/src/components/main/filter/Filter.tsx
+++ b/src/components/main/filter/Filter.tsx
@@ -10,6 +10,7 @@ import { useEmojiStore } from "@/lib/store/emojiStore";
 import { useCocktailStore } from "@/lib/store/cocktailStore";
 import { useFilterValueStore } from "@/lib/store/filterValueStore";
 import { filterData } from "@/lib/mokdata/filterData";
+import { useState } from "react";
 
 type TFilter = {
   onSearch: () => void;

--- a/src/components/main/slider/RangeSlider.module.scss
+++ b/src/components/main/slider/RangeSlider.module.scss
@@ -10,3 +10,8 @@
   width: 2rem;
   height: 2rem;
 }
+.label_txt {
+  font-size: 1.4rem;
+  color: $gray-400;
+  font-weight: $medium;
+}

--- a/src/components/main/slider/RangeSlider.tsx
+++ b/src/components/main/slider/RangeSlider.tsx
@@ -36,17 +36,21 @@ export default function RangeSlider({ whatSliderIsIt }: Props) {
     }
   };
 
-  const labelTxt = (value: number) => {
+  const handleLabel = (value: number) => {
     const emojiName =
       whatSliderIsIt === "booziness"
         ? filterData.booziness?.find((b) => b.value === value)?.emoji
         : filterData.sweetness?.find((s) => s.value === value)?.emoji;
 
+    const labelTxt =
+      whatSliderIsIt === "booziness"
+        ? filterData.booziness?.find((b) => b.value === value)?.name
+        : filterData.sweetness?.find((s) => s.value === value)?.name;
+
     const emojiUrl = emojiList.find((emoji) => emoji.name === emojiName)?.url;
 
     return (
       <div className={`${style.label_wrap}`}>
-        <div>{value}</div>
         <div className={`${style.emoji_imgWrap}`}>
           {emojiUrl && emojiName && (
             <Image
@@ -57,6 +61,7 @@ export default function RangeSlider({ whatSliderIsIt }: Props) {
             ></Image>
           )}
         </div>
+        <div className={`${style.label_txt}`}>{labelTxt}</div>
       </div>
     );
   };
@@ -72,11 +77,10 @@ export default function RangeSlider({ whatSliderIsIt }: Props) {
         marks={[
           {
             value: 0,
-            label: labelTxt(0),
+            label: handleLabel(0),
           },
-          { value: 1 },
-          { value: 5, label: labelTxt(5) },
-          { value: 10, label: labelTxt(10) },
+          { value: 5, label: handleLabel(5) },
+          { value: 10, label: handleLabel(10) },
         ]}
         valueLabelDisplay="auto"
         getAriaLabel={() => "Range slider"}

--- a/src/components/main/slider/RangeSlider.tsx
+++ b/src/components/main/slider/RangeSlider.tsx
@@ -35,7 +35,7 @@ export default function RangeSlider({ whatSliderIsIt }: Props) {
       console.log("sweetness", newValue);
     }
   };
-  console.log(emojiList);
+
   const labelTxt = (value: number) => {
     const emojiName =
       whatSliderIsIt === "booziness"

--- a/src/lib/mokdata/filterData.ts
+++ b/src/lib/mokdata/filterData.ts
@@ -9,18 +9,16 @@ export const filterData = {
   ],
   booziness: [
     {
+      name: "논알콜",
       emoji: "Smiling Face with Smiling Eyes",
       value: 0,
     },
-    {
-      emoji: "Monkey Face",
-      value: 5,
-    },
+    { name: "Medium", emoji: "Monkey Face", value: 5 },
     { name: "멍멍", emoji: "Dog Face", value: 10 },
   ],
   sweetness: [
-    { name: "달달함에 잠겨죽고싶다", emoji: "Honey Pot", value: 0 },
-    { name: "그냥 적당한거", emoji: "Wine Glass", value: 5 },
-    { name: "인생보다 쓴 맛", emoji: "Cigarette", value: 10 },
+    { name: "Sweet", emoji: "Honey Pot", value: 0 },
+    { name: "Medium", emoji: "Wine Glass", value: 5 },
+    { name: "Dry", emoji: "Cigarette", value: 10 },
   ],
 };

--- a/src/lib/store/cocktailStore.ts
+++ b/src/lib/store/cocktailStore.ts
@@ -30,8 +30,7 @@ export const useCocktailStore = create<TCocktailStore>((set, get) => ({
       Array.isArray(item.hashtag) ? item.hashtag.length !== 0 : false
     );
     const { uniqueBases, uniqueFlavors } = response;
-    console.log("이게 칵테일의 base와 flavor", uniqueBases, uniqueFlavors);
-    console.log("이게 칵테일 response", response);
+
     set({
       cocktailList: response.cocktails,
       totalCount: response.totalCount,

--- a/src/lib/store/filterValueStore.ts
+++ b/src/lib/store/filterValueStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { TCocktail } from "@/lib/types/TCocktail";
 
 type FilterState = {
   base: string[];
@@ -14,6 +15,9 @@ type FilterState = {
 
   filterClicked: boolean;
   setFilterClicked: (v: boolean) => void;
+
+  viewCocktailList: TCocktail[];
+  setViewCocktailList: (value: TCocktail[]) => void;
 };
 
 export const useFilterValueStore = create<FilterState>((set, get) => ({
@@ -58,5 +62,10 @@ export const useFilterValueStore = create<FilterState>((set, get) => ({
 
   setFilterClicked: (v) => {
     set({ filterClicked: v });
+  },
+
+  viewCocktailList: [],
+  setViewCocktailList: (value) => {
+    set({ viewCocktailList: value });
   },
 }));


### PR DESCRIPTION
![스크린샷 2025-06-23 오후 8 05 48](https://github.com/user-attachments/assets/cba58234-6809-486f-adee-4c2cf21159db)
- 모바일 필터 구현!
- pc버전도 필터의 초기화와 검색 버튼을 나란히 두었습니다!
- label 텍스트를 mokdata와 연결했습니다!
- 검색결과 칵테일은 zustand에 저장됩니다 (뒤로가기해도 결과 보존)

이슈
- 스크롤 업다운시 필터 버튼이 사라지는 문제가 있음