### PR TITLE
반응형 작업 하였습니다.

### DIFF
--- a/src/app/desc/[id]/desc.module.scss
+++ b/src/app/desc/[id]/desc.module.scss
@@ -268,6 +268,7 @@
     margin: 1rem 0;
   }
   @include respond(mobile) {
+    padding: 1rem;
     .upper {
       width: 80%;
       .nametagBox {

--- a/src/app/desc/[id]/desc.module.scss
+++ b/src/app/desc/[id]/desc.module.scss
@@ -44,10 +44,6 @@
           }
         }
       }
-      @include respond(mobile) {
-        .cocktailName {
-        }
-      }
     }
     .cocktailInfo {
       display: grid;
@@ -273,6 +269,7 @@
   }
   @include respond(mobile) {
     .upper {
+      width: 80%;
       .nametagBox {
         padding: 0;
         .cocktailName {
@@ -282,6 +279,10 @@
         }
         h2 {
           text-align: center;
+        }
+        .tagsBox {
+          justify-content: center;
+          flex-wrap: wrap;
         }
       }
       .cocktailInfo {

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -37,5 +37,5 @@ html {
 body {
   font-size: 1.6rem;
   margin-top: 7rem; //헤더크기 만큼 내려옴
-  height: 100vh;
+  height: 100vh -7rem // 헤더크기 제외한 높이;
 }

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -16,8 +16,13 @@ html {
   html {
     font-size: 50%;
     //  1rem = 8px
+  body {
+    margin-top: 2rem; // 모바일에서는 헤더가 없으므로 margin-top 제거
+    height: auto; // 모바일에서는 전체 높이를 auto로 설정
+    }
   }
 }
+
 
 * {
   margin: 0;

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -37,5 +37,5 @@ html {
 body {
   font-size: 1.6rem;
   margin-top: 7rem; //헤더크기 만큼 내려옴
-  height: 100vh -7rem // 헤더크기 제외한 높이;
+  height: 100vh;
 }

--- a/src/app/mypage/Mypage.module.scss
+++ b/src/app/mypage/Mypage.module.scss
@@ -7,7 +7,6 @@
   justify-content: center;
   align-items: center;
   height: 100vh;
-  background-color: $gray-100;
   .profile_image {
     height: 8rem;
     font-size: 11rem;;

--- a/src/app/mypage/Mypage.module.scss
+++ b/src/app/mypage/Mypage.module.scss
@@ -6,7 +6,8 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 90%;
+  height: 100vh;
+  background-color: $gray-100;
   .profile_image {
     height: 8rem;
     font-size: 11rem;;
@@ -83,6 +84,7 @@
   }
 
   @include respond(mobile) {
+    overflow: hidden;
     .button {
       h4 {
         font-size: 1.5rem;

--- a/src/app/storage/storage.module.scss
+++ b/src/app/storage/storage.module.scss
@@ -71,11 +71,10 @@
   .favorite_card_container {
     display: grid;
     position: relative;
-    justify-items: start;
+    justify-items: center;
     align-items: center;
     grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr)); 
     width: 100%;
-    gap: 2rem;
   }
   .empty_message {
     display: flex;
@@ -91,7 +90,30 @@
       color: $gray-200
     }
   }
+  @include respond(mobile) {
+    padding: 1rem;
+    gap: 3rem;
+    justify-content: center;
+    .favorite_card_container{
+      grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr)); 
+    }
+  }
+  @include respond(tablet) {
+    padding: 2rem;
+    gap: 3rem;
+    justify-content: center;
+    .favorite_card_container{
+      grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr)); 
+    }
+  }
+  @include respond(laptop) {
+    padding: 3rem;
+    gap: 4rem;
+    justify-content: flex-start; 
+    align-items: flex-start;
+    .favorite_card_container{
+      grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr)); 
+    }
+  }
 }
-
-
 

--- a/src/components/common/header/Login.module.scss
+++ b/src/components/common/header/Login.module.scss
@@ -29,7 +29,7 @@
 .after_login_btn {
   height: 5rem;
   width: 5rem;
-  padding: 2rem;
+  padding: 0.6rem;
   border-radius: 20rem;
   background-color: rgb(252, 198, 97);
   display: flex;

--- a/src/components/common/header/LoginBtn.tsx
+++ b/src/components/common/header/LoginBtn.tsx
@@ -7,14 +7,15 @@ import Image from "next/image";
 
 import { signIn, useSession } from "next-auth/react";
 import { usePathname } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useUserStore } from "@/lib/store/userStore";
+import { useLockButton } from "@/lib/hooks/useLockButton";
 import { getProfile } from "@/lib/fetchs/fetchProfile";
 
 export default function LoginBtn() {
   const { data: session, status } = useSession();
-  const [isClicked, setIsClicked] = useState(false);
   const { profileImageState, setProfile } = useUserStore();
+  const { locked, run } = useLockButton("login");
   const pathname = usePathname();
 
   useEffect(() => {
@@ -25,23 +26,21 @@ export default function LoginBtn() {
     if (session) {
       fetchProfile();
     }
-  }, []);
+  }, [session]);
 
-  const handleLogin = async () => {
-    try {
-      console.log("🚀 카카오 로그인 시도");
-      setIsClicked(true);
-      console.log(session);
-      await signIn("kakao");
-    } catch (error) {
-      alert("로그인에 실패했습니다. 다시 시도해주세요.");
-      console.error("🚨 로그인 실패", error);
-      setIsClicked(false);
-    } finally {
-      setIsClicked(false);
-    }
+  const handleLogin = () => {
+    run(async () => {
+      try {
+        console.log("🚀 카카오 로그인 시도");
+        await signIn("kakao");
+      } catch (error) {
+        alert("로그인에 실패했습니다. 다시 시도해주세요.");
+        console.error("🚨 로그인 실패", error);
+      }
+    });
   };
 
+  // 1. 로딩 중이면 스피너
   if (status === "loading") {
     return (
       <button className={style.before_login_btn} disabled>
@@ -50,6 +49,7 @@ export default function LoginBtn() {
     );
   }
 
+  // 2. 로그인된 상태 (프로필 이미지 or 아이콘)
   if (session) {
     return (
       <Link
@@ -67,24 +67,22 @@ export default function LoginBtn() {
             className={`${style.login_svg}`}
           />
         ) : (
-          <Person />
+          <Person width={50} height={50} />
         )}
       </Link>
     );
   }
-
+  // 3. 미로그인 상태(버튼만)
   return (
-    <>
-      {!isClicked ? (
-        <button className={style.before_login_btn} onClick={handleLogin}>
-          <Person className={style.login_svg} />
-          <div className={style.login_txt}>login</div>
-        </button>
-      ) : (
-        <button className={style.login_btn} disabled>
-          <div className={style.spinner}></div>
-        </button>
-      )}
-    </>
+    <button
+      className={style.before_login_btn}
+      disabled={locked}
+      onClick={() => {
+        handleLogin();
+      }}
+    >
+      <Person className={style.login_svg} />
+      <div className={style.login_txt}>login</div>
+    </button>
   );
 }

--- a/src/components/common/header/LoginBtn.tsx
+++ b/src/components/common/header/LoginBtn.tsx
@@ -19,12 +19,12 @@ export default function LoginBtn() {
 
   useEffect(() => {
     const fetchProfile = async () => {
-      const res = await getProfile(); // ✅ 여기서 결과값 받아옴
+      const res = await getProfile();
       setProfile(res.nickname, res.profileImage);
-      // 여기서 res.nickname 등으로 직접 접근 가능
     };
-
-    fetchProfile();
+    if (session) {
+      fetchProfile();
+    }
   }, []);
 
   const handleLogin = async () => {

--- a/src/components/common/header/header.module.scss
+++ b/src/components/common/header/header.module.scss
@@ -29,25 +29,12 @@
       gap: 1rem;
     }
     ul {
-      margin-left: 3rem;
       display: flex;
       flex-direction: row;
       align-items: center;
       gap: 14rem;
       position: relative;
       margin-left: 14rem;
-      margin-right: 12rem;
-      .menu_item {
-        cursor: pointer;
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-      }
-      .menu_item:hover {
-        color: $gray-400;
-        transition: all 0.2s ease-in-out;
-      }
-
       .search_btn {
         display: flex;
         gap: 1rem;
@@ -60,6 +47,22 @@
             stroke-width: 3;
           }
         }
+      }
+    }
+  }
+  @include respond(tablet) {
+    .nav_container{
+      ul {
+        margin-left: 1rem;
+        gap: 1rem;
+      }
+    }
+  }
+  @include respond(laptop) {
+    .nav_container{
+      ul {
+        margin-left: 2rem;
+        gap: 5rem;
       }
     }
   }

--- a/src/components/common/header/header.module.scss
+++ b/src/components/common/header/header.module.scss
@@ -35,6 +35,7 @@
       gap: 14rem;
       position: relative;
       margin-left: 14rem;
+      cursor: pointer;
       .search_btn {
         display: flex;
         gap: 1rem;

--- a/src/components/common/navigation/Navigation.module.scss
+++ b/src/components/common/navigation/Navigation.module.scss
@@ -15,7 +15,7 @@
   justify-content: space-evenly;
   align-items: center;
   padding-left: 0.7rem;
-
+  z-index: 1000;
   li {
     display: flex;
     align-items: center;

--- a/src/components/main/FilterSection.module.scss
+++ b/src/components/main/FilterSection.module.scss
@@ -1,125 +1,139 @@
 @import "@/styles/theme";
+@import "@/styles/mixin";
 
 .filter_section {
-  width: 98vw;
+  width: 100%;
   height: 110rem;
   margin-bottom: 10rem;
-  text-wrap: nowrap;
   padding-top: 7rem;
-
-  h1 {
-    width: fit-content;
-    font-size: 5.5rem;
-    color: $main-color;
-    font-weight: $bold;
-    user-select: none;
-  }
-
   .filter_card_wrap {
     display: grid;
-    grid-template-columns: 1fr 2.5fr;
-    column-gap: 2rem;
+    grid-template-columns: 1fr 2.5fr 0.4fr;
+    column-gap: 1rem;
     width: 100%;
-    // overflow: auto;
-  }
-
-  //pc 필터
-  .fitler_wrap {
-    box-shadow: $shadow;
-    border-radius: 0 2rem 2rem 0;
-    width: 42rem;
-    height: 100vh;
-    padding: 0rem 5rem;
-    background-color: white;
-    display: flex;
-    flex-direction: column;
-    justify-items: center;
-    position: sticky;
-    top: 7rem;
-    left: 0rem;
-  }
-
-  //모바일
-  .filter_btn {
-    position: fixed;
-    z-index: 4;
-    width: 100vw;
-    height: 6rem;
-    bottom: 7rem;
-    background-color: white;
-    border: none;
-    box-shadow: $shadow;
-    border-radius: 4rem 4rem 0 0;
-    font-size: 2.2rem;
-    font-weight: $bold;
-    color: $main-color;
-    cursor: pointer;
-
-    transition: opacity 0.3s;
-    opacity: 1;
-    //버튼 클릭시
-    &.hide {
-      opacity: 0;
-      pointer-events: none;
-    }
-  }
-  .filter_modal {
-    background-color: white;
-    z-index: 4;
-    width: 100vw;
-    position: fixed;
-    bottom: 7rem;
-    opacity: 0;
-    box-shadow: $shadow;
-    border-radius: 4rem 4rem 0 0;
-    // 애니메이션
-    transform: translateY(100%);
-    transition: transform 0.35s cubic-bezier(0.58, 0.93, 0.66, 1), opacity 0.1s;
-
-    &.open {
-      transform: translateY(0);
-      opacity: 1;
-    }
-
-    .modal_header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 2rem 4rem 0 4rem;
-    }
-    .title {
-      font-size: 3.4rem;
+    // overflow: hidden;
+    .filter_btn {
+      position: fixed;
+      z-index: 4;
+      width: 100%;
+      height: 6rem;
+      bottom: 7rem;
+      background-color: white;
+      border: none;
+      box-shadow: $shadow;
+      border-radius: 4rem 4rem 0 0;
+      font-size: 2.2rem;
       font-weight: $bold;
       color: $main-color;
-    }
-    .close_btn {
-      position: relative;
-      right: 0em;
       cursor: pointer;
-    }
 
-    .modal_fitler_wrap {
-      padding: 0rem 7rem;
+      transition: opacity 0.3s;
+      opacity: 1;
+      //버튼 클릭시
+      &.hide {
+        opacity: 0;
+        pointer-events: none;
+      }
+    }
+    //모바일
+    .filter_modal {
+      background-color: white;
+      z-index: 4;
+      width: 100%;
+      position: fixed;
+      bottom: 7rem;
+      opacity: 0;
+      box-shadow: $shadow;
+      border-radius: 4rem 4rem 0 0;
+      // 애니메이션
+      transform: translateY(100%);
+      transition: transform 0.35s cubic-bezier(0.58, 0.93, 0.66, 1), opacity 0.1s;
+
+      &.open {
+        transform: translateY(0);
+        opacity: 1;
+      }
+
+      .modal_header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 2rem 4rem 0 4rem;
+        .title {
+          font-size: 3.4rem;
+          font-weight: $bold;
+          color: $main-color;
+        }
+        .close_btn {
+          position: relative;
+          right: 0em;
+          cursor: pointer;
+        }
+      }
+      .modal_fitler_wrap {
+        padding: 0rem 7rem;
+      }
+    }
+    .filterTitle {
+      width: fit-content;
+      font-size: 5.5rem;
+      color: $main-color;
+      font-weight: $bold;
+      user-select: none;
+    }
+    //pc 필터
+    .fitler_wrap {
+      box-shadow: $shadow;
+      border-radius: 0 2rem 2rem 0;
+      width: 42rem;
+      height: 100vh;
+      padding: 0rem 5rem;
+      background-color: white;
+      display: flex;
+      flex-direction: column;
+      justify-items: center;
+      position: sticky;
+      top: 7rem;
+      left: 0rem;
+    }
+    .card_wrap {
+      overflow: visible;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding: 2rem;
+      .nomore_data {
+        font-size: 5rem;
+        color: $main-color;
+        font-weight: $bold;
+        margin-bottom: 5rem;
+        text-align: center;
+      }
     }
   }
-
-  .card_wrap {
-    overflow: visible;
+  @include respond(mobile) {
+    text-wrap: auto;
     width: 100%;
-    padding: 1rem 20rem 1rem 1rem;
+    .filter_card_wrap {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      text-align: center;
+      .card_wrap {
+        padding: 1rem;
+      }
+    }
   }
-  .nomore_data {
-    font-size: 5rem;
-    color: $main-color;
-    font-weight: $bold;
-    margin-bottom: 5rem;
-    text-align: center;
-  }
-  .loading {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    @include respond(tablet) {
     width: 100%;
-    height: 100%;
+    .filter_card_wrap {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      .card_wrap {
+        padding: 0;
+      }
+    }
   }
 }

--- a/src/components/main/FilterSection.tsx
+++ b/src/components/main/FilterSection.tsx
@@ -142,7 +142,7 @@ export default function FilterSection() {
         ) : (
           //pc
           <div>
-            <h1>Filter</h1>
+            <h1 className={`${style.filterTitle}`}>Filter</h1>
             <div className={`${style.fitler_wrap}`}>
               <Filter onSearch={handleFilter} onReset={handelReset} />
             </div>

--- a/src/components/top100/Top100.module.scss
+++ b/src/components/top100/Top100.module.scss
@@ -1,4 +1,5 @@
 @import "@/styles/theme";
+@import "@/styles/mixin";
 
 .top100_section {
   margin-top: 5rem;
@@ -6,18 +7,20 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
+  height: 90vh;
   .title {
     font-size: 5.5rem;
     color: $main-color;
     font-weight: $bold;
     text-wrap: nowrap;
+    margin-bottom: 5rem;
   }
-
   .slide_area {
     width: 75%;
-    height: 30rem;
+    height: 100%;
+    max-height: 55rem;
     justify-content: center;
-    margin-top: 7rem;
+    align-items: stretch;
     display: flex;
     flex-direction: row;
     gap: 1rem;
@@ -29,16 +32,119 @@
       .left_svg {
         position: absolute;
         left: 10rem;
+        top: 45%;
       }
       .right_svg {
         transform: scaleX(-1);
         position: absolute;
         right: 10rem;
-
+        top: 45%;
+      }
+    }
+    .top100_swiper {
+      height: 100%;
+      max-width: 100%;
+      max-height: 50rem;
+      display: flex;
+      flex-direction: column;
+      padding: 1rem;
+      :global(.swiper-pagination) {
+        margin-top: 3rem;
+        position: relative;
+        z-index: 2;
+      }
+      .active {
+        .cocktailBox {
+          box-shadow: $shadow;
+          border-radius: 3rem;
+          overflow: hidden;
+          width: 100%;
+          height:100%;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          img {
+            transform: scale(1.15); 
+            transition: transform 0.3s ease;
+            margin-bottom: 3rem;
+            cursor: pointer;
+            &:hover {
+              transform: scale(1.3);
+            }
+          }
+          p {
+            transition: color 0.3s ease;
+            color: $main-color;
+            font-size: large;
+          }
+        }
+      }
+      .non_active {
+        margin-bottom: 2rem;
+        cursor: pointer;
+        .cocktailBox {
+          margin: 0 auto;
+          overflow: hidden;
+          width: 100%;
+          height:100%;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          img{
+            margin-bottom: 3rem;
+          }
+          &:hover {
+            box-shadow: $shadow;
+            border-radius: 3rem;
+            img {
+              transform: scale(1.15); 
+              transition: transform 0.3s ease;
+            }
+            p {
+              font-size: large;
+              color: $main-color;
+              transition: 0.3s ease;
+            }
+          }
+        }
+      }
+      .cocktailImage {
+        user-select: none;
+        -webkit-user-drag: none;
+        flex-shrink: 0;
+        padding: 1rem;
+      }
+      .center_name_ko {
+        font-weight: $medium;
+        font-size: medium;
+        user-select: none;
+        -webkit-user-drag: none;
+      }
+      .center_name_en {
+        user-select: none;
+        color: $gray-300;
+        -webkit-user-drag: none;
       }
     }
   }
-
+  .spinner {
+    border: 0.4rem solid $gray-200;
+    border-top: 0.4rem solid white;
+    border-radius: 50%;
+    width: 5rem;
+    height: 5rem;  
+    animation: spin 0.8s linear infinite;
+    margin-left: 0.5rem;
+    margin-top: 15rem;
+    margin-bottom: 15rem;
+  }
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
   .find_top100_btn {
     outline: none;
     user-select: none;
@@ -51,111 +157,134 @@
     font-size: 1.8rem;
     padding: 1rem 0;
     position: relative;
-    margin-top: 20rem;
     cursor: pointer;
     &:hover {
       background-color: $gray-100;
       transition: 0.2s ease-in;
     }
   }
-}
 
-.top100_swiper {
-  width: 70vw; 
-  max-width: 85vw;
-  height: 48rem;
-}
-.swiper-wrapper {
-}
-.swiper-slide {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-}
-.active {
-  .cocktailBox {
-    padding: 1rem 1.5rem 1rem 1.5rem;
-    margin: 0 0.2rem 0 0.2rem;
-    position: absolute;
-    top: 2rem;
-    left: 1rem;
-    box-shadow: $shadow;
-    border-radius: 3rem;
-    overflow: hidden;
-  }
-  img {
-    position: relative;
-    transform: scale(1.15); 
-    transition: transform 0.3s ease;
-    cursor: pointer;
-    &:hover {
-      transform: scale(1.3);
+  @include respond(mobile) {
+    height: auto;
+    // background-color: $gray-200;
+    margin-top: 0;
+    .title {
+      font-size: 4rem;
+      margin-bottom: 0;
     }
-  }
-  p {
-    transition: color 0.3s ease;
-    color: $main-color;
-    font-size: medium;
-  }
-}
-.non_active {
-  cursor: pointer;
-  .cocktailBox {
-    &:hover {
-      box-shadow: $shadow;
-      border-radius: 3rem;
-      overflow: hidden;
-      img {
-        transform: scale(1.15); 
-        transition: transform 0.3s ease;
+    .slide_area {
+      width: 100%;
+      height: 45rem;
+      .slide_btn {
+        position: relative;
+        margin-top: 0;
+        z-index: 100;
+        top: -10rem;
+        .left_svg {
+          left: 1rem;
+        }
+        .right_svg {
+          right: 1rem;
+        }
+      }
+      .top100_swiper {
+        display: block;
+        max-height: 100%;
+        :global(.swiper-pagination) {
+        z-index: 2;
+        position: relative;
+        }
+        :global(.swiper-wrapper) {
+          height: 80%
+        }
+        .active {
+          box-shadow: none;
+        }
+        .non_active {
+          height: 100%;
+          .cocktailBox {
+            height: 100%;
+            width: 55%;
+            padding: 1rem;
+            img {
+              width:17rem;
+              height: 25rem;
+              margin-bottom: 0.5rem;
+              &:hover {
+                transform: scale(1.1);
+              }
+            }
+            p {
+              font-size: 1.5rem;
+            }
+            &:hover {
+              p {
+                font-size: 1.5rem;
+              }
+            }
+          }
+        }
       }
     }
-    padding: 1rem 1.5rem 1rem 1.5rem;
-    margin: 0 0.2rem 0 0.2rem;
-    position: absolute;
-    top: 2rem;
-    left: 1rem;
+    .find_top100_btn {
+      margin-top: 0;
+      width: 60%;
+    }
+  }
+  @include respond(tablet) {
+    height: 80rem;
+    .slide_area{
+      .top100_swiper{
+        .active{
+          display: flex;
+          justify-content: center;
+          .cocktailBox {
+            width: 30rem;
+          }
+        }
+      }
+    }
+  }
+  @include respond(laptop) {
+    .slide_area{
+      width: 100%;
+      .slide_btn {
+        position: relative;
+        margin-top: 0;
+        z-index: 100;
+        top: -10rem;
+        .left_svg {
+          left: 1rem;
+        }
+        .right_svg {
+          right: 1rem;
+        }
+      }
+      .top100_swiper{
+        width: 80%;
+      }
+    }
+  }
+  @include respond(pc) {
+    .slide_area{
+      width: 100%;
+      .slide_btn {
+        position: relative;
+        margin-top: 0;
+        z-index: 100;
+        top: -10rem;
+        .left_svg {
+          left: 1rem;
+        }
+        .right_svg {
+          right: 1rem;
+        }
+      }
+      .top100_swiper{
+        width: 80%;
+      }
+    }
   }
 }
-.center_name_ko {
-  font-weight: $medium;
-  font-size: small;
-  position: relative;
-  justify-content: center;
-  text-align: center;
-  outline: none;
-  user-select: none;
-  -webkit-user-drag: none;
 
-}
-.center_name_en {
-  color: $gray-400;
-  outline: none;
-  user-select: none;
-  -webkit-user-drag: none;
 
-}
-.cocktailImage {
-  outline: none;
-  user-select: none;
-  -webkit-user-drag: none;
-  flex-shrink: 0;
-  padding: 1rem;
-}
-.spinner {
-  border: 0.4rem solid $gray-200;
-  border-top: 0.4rem solid white;
-  border-radius: 50%;
-  width: 5rem;
-  height: 5rem;  
-  animation: spin 0.8s linear infinite;
-  margin-left: 0.5rem;
-  margin-top: 15rem;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/src/components/top100/Top100.module.scss
+++ b/src/components/top100/Top100.module.scss
@@ -188,17 +188,39 @@
         }
       }
       .top100_swiper {
-        display: block;
         max-height: 100%;
         :global(.swiper-pagination) {
         z-index: 2;
         position: relative;
         }
         :global(.swiper-wrapper) {
-          height: 80%
+          height: 80%;
         }
         .active {
-          box-shadow: none;
+          display: flex;
+          justify-content: center;
+          height: 100%;
+          .cocktailBox {
+            height: 100%;
+            width: 55%;
+            padding: 1rem;
+            img {
+              width:17rem;
+              height: 25rem;
+              margin-bottom: 0.5rem;
+              &:hover {
+                transform: scale(1.1);
+              }
+            }
+            p {
+              font-size: 1.5rem;
+            }
+            &:hover {
+              p {
+                font-size: 1.5rem;
+              }
+            }
+          }
         }
         .non_active {
           height: 100%;

--- a/src/components/top100/Top100.tsx
+++ b/src/components/top100/Top100.tsx
@@ -6,7 +6,7 @@ import RightSlide from "@public/LeftSlide.svg";
 import Image from "next/image";
 
 import { Swiper, SwiperSlide } from "swiper/react";
-import { Pagination } from "swiper/modules";
+import { Pagination, Autoplay } from "swiper/modules";
 
 import "swiper/css";
 import "swiper/css/pagination";
@@ -80,7 +80,11 @@ export default function Top100() {
             pagination={{
               clickable: true,
             }}
-            modules={[Pagination]}
+            modules={[Pagination, Autoplay]}
+            autoplay={{
+              delay: 3000,
+              disableOnInteraction: false,
+            }}
             className={`${style.top100_swiper}`}
             onSlideChange={(e) => {
               setRealIndex(

--- a/src/components/top100/Top100.tsx
+++ b/src/components/top100/Top100.tsx
@@ -42,6 +42,23 @@ export default function Top100() {
   const handleToTop100 = () => {
     router.push("/find?linkTop100=1");
   };
+  function getSlideRealIndex(realIndex: number, slideCount: number) {
+    const width = window.innerWidth;
+    if (width <= 720) {
+      // 720px 이하: 모바일
+      return realIndex;
+    } else if (width <= 1440) {
+      // 721~1440px: 태블릿/노트북
+      return realIndex + 1 > slideCount - 1
+        ? realIndex - (slideCount - 1)
+        : realIndex + 1;
+    } else {
+      // 1441px 이상: 데스크탑
+      return realIndex + 2 > slideCount - 1
+        ? realIndex - (slideCount - 2)
+        : realIndex + 2;
+    }
+  }
   return (
     <div className={style.top100_section}>
       <h1 className={style.title}>
@@ -65,13 +82,14 @@ export default function Top100() {
             }}
             modules={[Pagination]}
             className={`${style.top100_swiper}`}
-            onSlideChange={(e) =>
+            onSlideChange={(e) => {
               setRealIndex(
-                e.realIndex + 2 > randomCocktailsRef.current.length - 1
-                  ? e.realIndex - (randomCocktailsRef.current.length - 2)
-                  : e.realIndex + 2
-              )
-            }
+                getSlideRealIndex(
+                  e.realIndex,
+                  randomCocktailsRef.current.length
+                )
+              );
+            }}
             breakpoints={{
               // 0px 이상에서는 1개
               0: {
@@ -79,18 +97,18 @@ export default function Top100() {
                 spaceBetween: 10,
               },
               // 640px 이상(태블릿)
-              640: {
-                slidesPerView: 2,
-                spaceBetween: 15,
+              720: {
+                slidesPerView: 3,
+                spaceBetween: 10,
               },
               // 1024px 이상(데스크탑)
               1024: {
                 slidesPerView: 3,
                 spaceBetween: 30,
               },
-              1460: {
-                slidesPerView: 4,
-                spaceBetween: 30,
+              1440: {
+                slidesPerView: 5,
+                spaceBetween: 15,
               },
               1700: {
                 slidesPerView: 5,

--- a/src/styles/_mixin.scss
+++ b/src/styles/_mixin.scss
@@ -20,7 +20,7 @@ $pc: 1440px;
       @content;
     }
   } @else if $breakpoint == pc {
-    @media (min-width: $pc) {
+    @media (min-width: $laptop) and (max-width: #{$pc - 1px}) {
       @content;
     }
   }

--- a/src/styles/_mixin.scss
+++ b/src/styles/_mixin.scss
@@ -12,11 +12,11 @@ $pc: 1440px;
       @content;
     }
   } @else if $breakpoint == tablet {
-    @media (min-width: $mobile) and (max-width: #{$laptop - 1px}) {
+    @media (min-width: $mobile) and (max-width: #{$tablet - 1px}) {
       @content;
     }
   } @else if $breakpoint == laptop {
-    @media (min-width: $tablet) and (max-width: #{$pc - 1px}) {
+    @media (min-width: $tablet) and (max-width: #{$laptop - 1px}) {
       @content;
     }
   } @else if $breakpoint == pc {


### PR DESCRIPTION
### 반응형 및 리팩토링 작업 진행하였습니다. 
하다보니 정말 끝이 없길래... 계속 하게되었는데요,,, 정말 끝이 없습니다 6시간을 쉬지 않고 작업했습니다 수완님... 🤯🤯😨
#### 기타 스타일링
- 칵테일 창고의 모바일 카드가 이제 2줄로 렌더링 됩니다.
- 여태껏 잘못 사용하고 있던 mixin 범위를 수정하였습니다. 
- mixin을 만지다 알게된 이슈는  mixin 의 landscape 설정으로 932px 부터 919 정도까지 모바일로 인식하게 됩니다. 
- filterSection 모바일 화면에서 카드들이 2줄로 이쁘게 나옵니다. ( 소형 모바일 - 375px 은 1줄 )
- 네비게이션 bar z-index 를 가장 높게 ( 1000 값 ) 지정했습니다.
- 헤더의 메뉴 gap, margin 을 반응형으로  수정하여 tablet 크기에서도 모든 메뉴를 클릭 가능합니다.
- global.scss 에서 반응형 모바일 에서는 body 태그의 margin-top 이 2rem 으로 변경됩니다.
- 상세페이지 모바일 화면에서 태그 박스를 중앙정렬 및 화면 넓이의 100% 로 수정하였습니다.
- 마이 페이지가 모바일 화면에서 중앙이 아닌체 렌더링 되기에 height 수정하였습니다.
- 로그인 버튼을 눌렀을 때 정신없이 바뀌던 spinner 를 일관될 수 있도록 수정하였습니다.

#### top100 
- 이제 모바일에서도 중앙 정렬해 나옵니다.
- 반응형을 수정하였습니다. tablet, laptop, pc 스케일에서도 어색하지 않게 카드들이 나올 수 있도록 조정하였습니다.
- laptop, mobile, pc 스케일에서 슬라이더 화살표는 화면의 끝 단에 붙게 수정하였습니다. - 같이 확인하시죠.
- 모바일 스케일에서 나오는 이미지 크기를 대폭 줄였습니다. 